### PR TITLE
chores(ci): added sops secrets and bootstrap terraform configs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,64 @@
+name: Deployment
+
+on:
+  workflow_dispatch:
+    inputs:
+      intent:
+        type: choice
+        description: "Intent of running Terraform workflow"
+        default: plan
+        options:
+          - plan
+          - apply
+          - destroy
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Run Terraform
+    defaults:
+      run:
+        working-directory: deployment
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Authenticate to Security Token Service
+        uses: hkust-contrib/actions/authenticate@latest
+        with:
+          scope: sops:age_keypair
+
+      - name: Setup Terraform
+        uses: hkust-contrib/actions/setup-terraform@latest
+        with:
+          use_federated_token: true
+          state: projects/haputele
+
+      - name: Terraform Format
+        id: fmt
+        run: terraform fmt -check
+
+      - name: Terraform Init
+        id: init
+        run: terraform init
+
+      - name: Terraform Validate
+        id: validate
+        run: terraform validate -no-color
+
+      - name: Terraform Plan
+        id: plan
+        if: github.event.inputs.intent == 'plan' || github.event_name == 'push'
+        run: terraform plan -no-color
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event.inputs.intent == 'apply'
+        run: terraform apply -auto-approve
+
+      - name: Terraform Destroy
+        if: github.ref == 'refs/heads/main' && github.event.inputs.intent == 'destroy'
+        run: terraform destroy -auto-approve

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,8 +7,14 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'frontend/**'
+      - 'backend/**'
   workflow_dispatch:
 
 # Cancel an in-flight run when a newer commit lands on the same ref.

--- a/deployment/main.tf
+++ b/deployment/main.tf
@@ -1,0 +1,3 @@
+data "external" "env" {
+  program = ["jq", "-n", "env"]
+}

--- a/deployment/sops.tf
+++ b/deployment/sops.tf
@@ -1,0 +1,3 @@
+data "sops_file" "secrets" {
+  source_file = "../secrets.yaml"
+}

--- a/deployment/terraform.tf
+++ b/deployment/terraform.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "http" {}
+  required_providers {
+    sops = {
+      source  = "carlpett/sops"
+      version = "1.4.1"
+    }
+  }
+}

--- a/secrets.yaml
+++ b/secrets.yaml
@@ -1,0 +1,22 @@
+cloudflare_r2:
+    endpoint: ENC[AES256_GCM,data:Fpl1KgPdgE50mbNCVpJqTy01CPHE3N709GnYvWO3ggDh6HGPcTwHqpr2T3hpFyFtrJWCv8KR5yrMuZmzgMAwOxY=,iv:zfnJns4fVsz0W4SgK5zCOUKP4zNi738KHzMP4yxw7Gg=,tag:WYlhdq4zwVWfiWifdper7g==,type:str]
+    bucket_name: ENC[AES256_GCM,data:SZjucT+bEvo=,iv:anO7oPYBKfZbZOX00RnO1rFNaRRd2YTbuINzkyUS6QU=,tag:y4E05bYfv/upcDIFFwb41Q==,type:str]
+    access_key_id: ENC[AES256_GCM,data:s34bbEX5CU+aiPUiPGjr3CuQU9MkJvoIf9grk63MYZg=,iv:TVQVE4tX+mnKkkY40plUepuKJ3HAvWzeNYqYdi6ppKc=,tag:ggt6qqMNi4+LsCLUrijP8A==,type:str]
+    secret_access_key: ENC[AES256_GCM,data:QAPGFoSRdmilX9qxgK0CDbmwWiSaT1gdSB86dN+ruXlvTWn4Zo7BLU/ZjIE3WUMQu7JVC1ApmoxtZTbhL3Y9WA==,iv:roEF00vSXH1hXgjol0IaYDfusVQtUbWTrH1rD3n5HHU=,tag:YsYGz3m2XDk8v0SCPRu/SA==,type:str]
+resend:
+    api_key: ENC[AES256_GCM,data:nX3bVJPB97O8Vb01uj5H7q9R6Al1q0vDMzd0h5j0qIIp8Ldj,iv:c+3yT1eikm7YsuOreKMQA9UdZ3e/Kx6KxRU/nZGi9F0=,tag:VzUeVoPJn1g7msGImzEWng==,type:str]
+sops:
+    age:
+        - enc: |
+            -----BEGIN AGE ENCRYPTED FILE-----
+            YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSAzMnl0UmxqcHNsNXBZV01s
+            VFhBclJ2NGVlYWFpUkUwck5zdnBCTHMyZXk0CkZqNzNuYWpqR2F6cllyZ09yTExW
+            LzBidzk2U1hKTUhNczAzZ04rNS9pNjQKLS0tIDNqSERMSGhFWmJZaTBodkRKNGxx
+            S1hhQVZ6K2N0b3hXTlhDOGdsSlNUQ3cKCSyEWZCET2tkvNFBHM7oJCKEXU5NCo2C
+            U1HEH+8GF/iIgc8zGIkDPfWLWLw8haO6KB7iMLWolzFG6kLNoSAG0w==
+            -----END AGE ENCRYPTED FILE-----
+          recipient: age1ftk4fuk55afuuaxfctlm0na0u5q8hqxufulyauarsnezrqlreemq0xwkqa
+    lastmodified: "2026-05-29T08:23:25Z"
+    mac: ENC[AES256_GCM,data:YwXEf2JBJKJK9EA3TZTNXC7/S/iJ25hGkt/kFU4/Srf/DB+2Kjh773tJsHc3d3kmf7G9z1hRwkJ0T+zRF5DN89+E3vuDKZ2p/JG+q+BcLAeoT2I1NfGNB2NkggBjfNX+LxcxeH4Dxf3AVciBqHkaP18G8YYAuFdJMne2ecWzgOw=,iv:a0doEd4V44tC3FCObHBSdjzNBQh9yKibRjNmf/zpQg4=,tag:F6h382pvbp2JJhji3SP5vw==,type:str]
+    unencrypted_suffix: _unencrypted
+    version: 3.13.1


### PR DESCRIPTION
This pull request introduces infrastructure-as-code and secrets management for the project by adding Terraform configuration and a secure deployment workflow. The changes set up automated deployment using GitHub Actions, integrate SOPS for managing secrets, and make the Docker build workflow more efficient by triggering only on relevant file changes.

**Infrastructure as Code & Deployment Automation:**

* Added a new GitHub Actions workflow (`.github/workflows/deploy.yml`) to automate Terraform deployment, with support for plan, apply, and destroy actions, and secure authentication using federated tokens.
* Introduced Terraform configuration files (`deployment/main.tf`, `deployment/sops.tf`, `deployment/terraform.tf`) to manage infrastructure, including external environment data and SOPS secrets integration, and configured the HTTP backend and required providers. [[1]](diffhunk://#diff-7eb3ee0f98ada933aa3e4a260350c6c2b27b030633e9aa16afecba0ca056ef6fR1-R3) [[2]](diffhunk://#diff-a574b5a4ab7ceac336ca4e91c797e44a76745786e19ec52e3c6c1be97c9cd1f7R1-R3) [[3]](diffhunk://#diff-2406d30615ac79e5b946c5683d6f161b6cddbb6c5d5fb54b7aa6e22dcfd67f88R1-R9)

**Secrets Management:**

* Added an encrypted `secrets.yaml` file managed by SOPS, containing sensitive credentials for Cloudflare R2 and Resend, along with SOPS metadata and keys.

**CI/CD Workflow Optimization:**

* Updated the Docker GitHub Actions workflow (`.github/workflows/docker.yml`) to only trigger on changes within the `frontend` or `backend` directories, reducing unnecessary builds.