### PR TITLE
feat(email): invite-by-email doctor onboarding + admin approval

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -75,3 +75,25 @@ LIVEKIT_API_SECRET=devsecret-must-be-at-least-32-chars-long
 # this to whatever host browsers actually connect to: 127.0.0.1 for a
 # same-machine test, or your LAN IP if testing from a second device.
 LIVEKIT_NODE_IP=127.0.0.1
+
+# Resend (transactional email). Get the API key at
+# https://resend.com/api-keys — create one per env, scoped "Sending access".
+# RESEND_FROM must be on a domain you've verified in the Resend dashboard
+# (Domains → Add). Until you verify a domain, leave RESEND_API_KEY empty
+# (send_email() returns a 422 email_not_configured) OR set:
+#   RESEND_API_KEY=<your dev key>
+#   RESEND_FROM=onboarding@resend.dev
+# which only delivers to the email registered on your Resend account.
+# RESEND_WEBHOOK_SECRET is the `whsec_…` value shown when you add a webhook
+# endpoint pointing at /resend/webhook. Required to accept inbound events.
+RESEND_API_KEY=
+RESEND_FROM=
+RESEND_REPLY_TO=
+RESEND_WEBHOOK_SECRET=
+# Absolute URL of the frontend, used to build invite links in emails.
+# No trailing slash. In dev: http://localhost:3000
+FRONTEND_BASE_URL=
+# Hours a doctor invite token stays valid. Default 72h.
+DOCTOR_INVITE_TTL_HOURS=72
+# REMINDERS_INTERVAL removed — reminders now use Resend's `scheduled_at`
+# feature (fired at appointment creation, no cron container).

--- a/backend/alembic/versions/0009_email_suppressions.py
+++ b/backend/alembic/versions/0009_email_suppressions.py
@@ -1,0 +1,44 @@
+"""email suppression list
+
+Revision ID: 0007_email_suppressions
+Revises: 0006_system_init
+Create Date: 2026-05-28
+
+Adds the email_suppressions table. The Resend webhook handler writes
+into it on `email.bounced` (hard bounce) and `email.complained`
+events; services/email.py checks it before every outbound send.
+
+Stored email is the lowercased canonical form — callers and the
+webhook handler are responsible for lowercasing before insert/lookup
+so the primary-key constraint actually catches duplicates.
+
+reason is a free-form short string (typically the raw webhook event
+type, e.g. "bounced.hard" or "complained"), kept untyped so we don't
+have to migrate when Resend adds new event variants.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0009_email_suppressions"
+down_revision: Union[str, None] = "0008_blobs_to_s3"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS email_suppressions (
+            email      VARCHAR(320) PRIMARY KEY,
+            reason     VARCHAR(64) NOT NULL,
+            detail     JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS email_suppressions")

--- a/backend/alembic/versions/0010_email_invites_and_log.py
+++ b/backend/alembic/versions/0010_email_invites_and_log.py
@@ -1,0 +1,84 @@
+"""doctor invites + notification log
+
+Revision ID: 0008_email_invites_and_log
+Revises: 0007_email_suppressions
+Create Date: 2026-05-28
+
+Lands the email-driven doctor onboarding and reminder features:
+
+  1. doctor_invites — one-shot tokens that let an admin onboard a doctor
+     without typing their password. token_hash is sha256-hex (64 chars,
+     UNIQUE). A live row has consumed_at IS NULL AND expires_at > NOW().
+
+     One doctor can have multiple historical invite rows; we don't enforce
+     "at most one live invite per doctor" in the DB because rotation is a
+     valid operation (admin reissues if the doctor lost the link). The
+     onboarding endpoint accepts the most recent unconsumed/unexpired row.
+
+  2. notification_log — idempotency guard for any outbound notification.
+     dedup_key is a free-form string built by call sites (e.g.
+     "reminder.t-24h:appt-123", "doctor.invite:doctor-45"). UNIQUE means
+     the cron scanner can `INSERT … ON CONFLICT DO NOTHING` and only send
+     when the insert returned a row — exactly-once delivery becomes a
+     property of the table, not of the caller's locking.
+
+     We don't FK to appointments / accounts here because the table is
+     polymorphic: notifications about deleted entities should still be
+     queryable for audit. Call sites that want strong typing pass the
+     subject id inside dedup_key.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0010_email_invites_and_log"
+down_revision: Union[str, None] = "0009_email_suppressions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS doctor_invites (
+            id          SERIAL PRIMARY KEY,
+            doctor_id   INTEGER NOT NULL REFERENCES doctor(doctor_id) ON DELETE CASCADE,
+            token_hash  VARCHAR(64) NOT NULL UNIQUE
+                          CHECK (CHAR_LENGTH(token_hash) = 64),
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at  TIMESTAMPTZ NOT NULL,
+            consumed_at TIMESTAMPTZ
+        )
+        """
+    )
+    # Hot-path index: onboarding POST looks up by token_hash (already covered
+    # by UNIQUE) but the admin "re-issue invite" path also scans by doctor.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS doctor_invites_doctor_idx "
+        "ON doctor_invites (doctor_id, created_at DESC)"
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notification_log (
+            id            SERIAL PRIMARY KEY,
+            dedup_key     TEXT NOT NULL UNIQUE,
+            kind          TEXT NOT NULL,
+            recipient     TEXT NOT NULL,
+            sent_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            resend_msg_id TEXT
+        )
+        """
+    )
+    # The reminder cron also wants to "show me everything sent in the last
+    # hour" for ops visibility; sent_at index keeps that cheap.
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS notification_log_sent_at_idx "
+        "ON notification_log (sent_at DESC)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS notification_log")
+    op.execute("DROP TABLE IF EXISTS doctor_invites")

--- a/backend/alembic/versions/0011_invite_by_email_and_approval.py
+++ b/backend/alembic/versions/0011_invite_by_email_and_approval.py
@@ -1,0 +1,91 @@
+"""invite-by-email + admin approval workflow
+
+Revision ID: 0010_invite_email_approval
+Revises: 0009_appointment_reminder_refs
+Create Date: 2026-05-29
+
+Reshapes the invite + onboarding flow so the admin only types the
+doctor's email (and optionally a family-name hint for the greeting),
+and the doctor fills out every other field themselves. Adds an
+approval step so submissions are visible to the admin before the
+account is usable.
+
+Schema changes:
+
+  doctor_invites
+    - doctor_id   → NULLable. NULL means "this invite hasn't been
+                    consumed yet and there's no Doctor row for it" —
+                    the "new doctor" mode. Set when the invite is
+                    consumed via the self-onboarding form.
+    - email       → new NOT NULL column. Captured at issue time so
+                    we can address the invite, surface it on the
+                    onboarding page, and reject double-invites of
+                    the same address. Backfilled from the linked
+                    Doctor row for any pre-existing invites.
+    - family_name → optional name hint the admin can provide so the
+                    invite email reads "Hi Dr. Perera" instead of a
+                    generic greeting.
+
+  doctor
+    - approved_at      → TIMESTAMPTZ NULL. NULL = the doctor finished
+                          onboarding but hasn't been approved yet.
+                          NOT NULL = active and usable. Backfilled to
+                          NOW() for every existing doctor so the upgrade
+                          doesn't lock anyone out.
+    - rejected_at      → TIMESTAMPTZ NULL. Set when an admin rejects a
+                          submitted profile. Rejected doctors are also
+                          deactivated (active=false) by the route
+                          handler; the rejected_at flag preserves the
+                          audit trail.
+    - rejected_reason  → TEXT NULL. Free-form admin note. Surfaced on
+                          the doctor's "your submission was rejected"
+                          screen.
+
+No data migration beyond the approved_at backfill — pre-existing
+invite rows always have a linked doctor_id so the email backfill is
+non-empty.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0011_invite_email_approval"
+down_revision: Union[str, None] = "0010_email_invites_and_log"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # doctor_invites: relax doctor_id NOT NULL, add email + family_name.
+    op.execute("ALTER TABLE doctor_invites ALTER COLUMN doctor_id DROP NOT NULL")
+    op.execute("ALTER TABLE doctor_invites ADD COLUMN IF NOT EXISTS email TEXT")
+    op.execute("ALTER TABLE doctor_invites ADD COLUMN IF NOT EXISTS family_name TEXT")
+    # Backfill email from the linked doctor row, then enforce NOT NULL.
+    op.execute(
+        """
+        UPDATE doctor_invites di
+        SET email = d.email
+        FROM doctor d
+        WHERE di.doctor_id = d.doctor_id
+          AND di.email IS NULL
+        """
+    )
+    op.execute("ALTER TABLE doctor_invites ALTER COLUMN email SET NOT NULL")
+
+    # doctor: approval state.
+    op.execute("ALTER TABLE doctor ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE doctor ADD COLUMN IF NOT EXISTS rejected_at TIMESTAMPTZ")
+    op.execute("ALTER TABLE doctor ADD COLUMN IF NOT EXISTS rejected_reason TEXT")
+    # Pre-existing rows are implicitly approved — anything else would
+    # lock the clinic out of its current bookings on first deploy.
+    op.execute("UPDATE doctor SET approved_at = NOW() WHERE approved_at IS NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE doctor DROP COLUMN IF EXISTS rejected_reason")
+    op.execute("ALTER TABLE doctor DROP COLUMN IF EXISTS rejected_at")
+    op.execute("ALTER TABLE doctor DROP COLUMN IF EXISTS approved_at")
+    op.execute("ALTER TABLE doctor_invites DROP COLUMN IF EXISTS family_name")
+    op.execute("ALTER TABLE doctor_invites DROP COLUMN IF EXISTS email")
+    op.execute("ALTER TABLE doctor_invites ALTER COLUMN doctor_id SET NOT NULL")

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -89,5 +89,31 @@ class Settings(BaseSettings):
     S3_SECRET_ACCESS_KEY: str = ""
     S3_FORCE_PATH_STYLE: bool = True
 
+    # Resend (transactional email). API key stays server-side. RESEND_FROM
+    # must use a domain you've verified in the Resend dashboard; until a
+    # domain is verified, set RESEND_FROM to "onboarding@resend.dev" and
+    # note that delivery is restricted to the account-owner's email.
+    # RESEND_WEBHOOK_SECRET is the Svix signing secret shown when you add
+    # a webhook endpoint; required to accept POSTs on /resend/webhook.
+    # When RESEND_API_KEY is empty, send_email() raises a clean 422 so
+    # callers can branch on `email_not_configured` in dev/test.
+    RESEND_API_KEY: str = ""
+    RESEND_FROM: str = ""
+    RESEND_REPLY_TO: str = ""
+    RESEND_WEBHOOK_SECRET: str = ""
+
+    # Where the frontend lives — used by the email service to build absolute
+    # URLs in transactional templates (e.g. doctor invite links). No trailing
+    # slash. In dev with the Next.js dev server at :3000 set
+    # FRONTEND_BASE_URL=http://localhost:3000; in prod set it to your real
+    # https origin. If empty, send_templated() refuses to render any template
+    # that needs a link, because relative URLs in email don't resolve.
+    FRONTEND_BASE_URL: str = ""
+
+    # How long a doctor invite token is valid for, in hours. Default 72h
+    # (long weekend) gives a busy clinician enough slack but is short
+    # enough that a leaked link doesn't sit usable for weeks.
+    DOCTOR_INVITE_TTL_HOURS: int = 72
+
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -19,11 +19,13 @@ from .routers import (
     availability,
     consultations,
     doctors,
+    doctor_onboarding,
     exports,
     livekit_webhook,
     patients,
     preconsult,
     queue,
+    resend_webhook,
     setup,
     summary,
     sysadmin,
@@ -150,6 +152,8 @@ def create_app() -> FastAPI:
     app.include_router(summary.router)
     app.include_router(exports.router)
     app.include_router(livekit_webhook.router)
+    app.include_router(resend_webhook.router)
+    app.include_router(doctor_onboarding.router)
 
     @app.get("/health", tags=["meta"])
     def health() -> dict:

--- a/backend/app/middleware/setup_gate.py
+++ b/backend/app/middleware/setup_gate.py
@@ -18,7 +18,12 @@ from .request_id import REQUEST_ID_HEADER
 from ..services.system_config import get_system_config
 
 
-_ALWAYS_OPEN_EXACT = {"/health", "/openapi.json", "/livekit/webhook"}
+_ALWAYS_OPEN_EXACT = {
+    "/health",
+    "/openapi.json",
+    "/livekit/webhook",
+    "/resend/webhook",
+}
 _ALWAYS_OPEN_PREFIXES = ("/docs", "/redoc")
 
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -44,6 +44,14 @@ class Doctor(Base):
     institute_contact: Mapped[str] = mapped_column(String(255), nullable=False)
     rubber_stamp_key: Mapped[str] = mapped_column(String(512), nullable=False)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    # Approval workflow. Doctors self-onboard via an invite-by-email flow
+    # which creates the row but leaves approved_at NULL; an admin reviews
+    # and either calls /approve (stamps NOW) or /reject (stamps rejected_at
+    # + optional reason and deactivates). Backfilled to NOW() on the 0010
+    # migration so existing doctors stay usable across the upgrade.
+    approved_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    rejected_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    rejected_reason: Mapped[str | None] = mapped_column(Text)
 
 
 class Patient(Base):
@@ -271,3 +279,95 @@ class QueueEntry(Base):
     booked_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     cancelled_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
     cancellation_reason: Mapped[str | None] = mapped_column(Text)
+
+
+class EmailSuppression(Base):
+    """Addresses we must not send transactional email to.
+
+    Populated by the Resend webhook handler when an `email.bounced`
+    (hard bounce only) or `email.complained` event arrives. `reason`
+    is the raw webhook event type so an operator can tell at a glance
+    why an address was suppressed. Lookups by lowercased address are
+    O(1) via the primary key, so send_email() can cheaply gate every
+    outbound message on this table.
+    """
+    __tablename__ = "email_suppressions"
+
+    email: Mapped[str] = mapped_column(String(320), primary_key=True)
+    reason: Mapped[str] = mapped_column(String(64), nullable=False)
+    detail: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb")
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+
+
+class DoctorInvite(Base):
+    """One-shot onboarding token for a newly-created doctor account.
+
+    Issued by `POST /doctors` (or the re-issue endpoint) when the
+    admin chooses "invite by email" instead of typing a password. The
+    Account row exists with a random password; the doctor receives a
+    link containing the raw token (NOT the hash), follows it, sets
+    their real password, and we mark the row consumed.
+
+    Liveness predicate: `consumed_at IS NULL AND expires_at > NOW()`.
+    Multiple historical rows per doctor are allowed (re-issue flow);
+    the onboarding endpoint picks the most recent live row.
+    """
+    __tablename__ = "doctor_invites"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    # NULL for "new-doctor" invites issued by email before any Doctor row
+    # exists. The onboarding-complete path fills this in atomically with
+    # the new Doctor row's id.
+    doctor_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("doctor.doctor_id", ondelete="CASCADE")
+    )
+    # Captured at invite time. The onboarding page surfaces this so the
+    # doctor sees "you're setting up the account that invite went to".
+    # Also used to reject double-invites for the same address.
+    email: Mapped[str] = mapped_column(Text, nullable=False)
+    # Optional admin-provided name hint, used purely to personalise the
+    # invite email's greeting. Doctor's actual family name is captured
+    # in the onboarding form.
+    family_name: Mapped[str | None] = mapped_column(Text)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
+class NotificationLog(Base):
+    """Idempotency record for every outbound notification.
+
+    `dedup_key` is the unique identity of a "thing we should send once",
+    constructed by the caller — e.g. `"reminder.t-24h:appt-123"` or
+    `"doctor.invite:doctor-45"`. The UNIQUE constraint means a cron
+    scanner can rely on `INSERT … ON CONFLICT DO NOTHING RETURNING id`
+    to atomically claim a send slot: if the insert returned a row the
+    caller is responsible for sending; if it didn't, someone else (or
+    a previous run) already sent it.
+
+    `kind` is the category (used for filtering / reporting);
+    `recipient` is the email address we sent to; `resend_msg_id` is the
+    Resend message id (populated after the API call, so a row in the
+    table with NULL resend_msg_id means "claimed to send but the API
+    call hasn't completed yet" — see send_reminders.py for the
+    claim → send → update sequence).
+    """
+    __tablename__ = "notification_log"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    dedup_key: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
+    kind: Mapped[str] = mapped_column(Text, nullable=False)
+    recipient: Mapped[str] = mapped_column(Text, nullable=False)
+    sent_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    resend_msg_id: Mapped[str | None] = mapped_column(Text)
+
+

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,10 +1,12 @@
 from fastapi import APIRouter, Depends, Response
 from sqlalchemy.orm import Session
 
+from sqlalchemy import select
+
 from ..config import settings
 from ..deps import CurrentUser, current_user, db_dep
-from ..errors import unauthorized
-from ..models import Account
+from ..errors import forbidden, unauthorized
+from ..models import Account, Doctor
 from ..schemas import LoginIn, LoginOut, MeOut
 from ..security import (
     clear_session_cookies,
@@ -34,6 +36,21 @@ def login(
         raise unauthorized(INVALID_CREDENTIALS)
     if payload.role and payload.role != account.role:
         raise unauthorized(INVALID_CREDENTIALS)
+
+    # Approval gate for self-onboarded doctors. We check AFTER password
+    # verification so a wrong password still returns the generic
+    # invalid_credentials code — an attacker who doesn't know the password
+    # gets the same response either way. Only the legitimate owner sees
+    # the specific pending/rejected code, which is what they need to
+    # understand why they can't get in.
+    if account.role == "doctor":
+        doctor = db.scalar(select(Doctor).where(Doctor.username == account.username))
+        if doctor is not None:
+            if doctor.rejected_at is not None:
+                raise forbidden("account_rejected")
+            if doctor.approved_at is None:
+                raise forbidden("account_pending_approval")
+
     token, expires = create_token(account.username, account.role)
     set_session_cookies(
         response,

--- a/backend/app/routers/doctor_onboarding.py
+++ b/backend/app/routers/doctor_onboarding.py
@@ -1,0 +1,148 @@
+"""Public doctor-onboarding endpoints — token-authenticated, no session.
+
+A doctor receives an emailed link of the form
+
+    {FRONTEND_BASE_URL}/doctor-onboarding/{raw_token}
+
+The frontend mounts a page at that path which:
+  1. GETs /doctor-onboarding/{token} — verifies the token is live and
+     learns which flow this invite belongs to (rotation vs new doctor).
+  2. POSTs /doctor-onboarding/{token} with either:
+       - rotation: just {password}
+       - new doctor: the full profile + username + password
+
+These endpoints intentionally bypass our normal auth + CSRF stack: the
+doctor isn't logged in yet, and there is no session cookie to defend.
+The raw token (32 bytes of url-safe entropy) IS the credential, and
+its single-use lifecycle is enforced inside services/doctor_invites.py.
+
+Setup gate: post-init this path passes through normally (no `/setup/`
+prefix). Pre-init the gate 409s setup_required, which is correct —
+no doctors exist before first-run setup completes.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Body, Depends, Response, status
+from sqlalchemy.orm import Session
+
+from ..deps import db_dep
+from ..errors import unprocessable
+from ..models import Doctor
+from ..schemas import DoctorOnboardingPeek, DoctorOnboardingSubmit
+from ..services import doctor_invites as invites
+from ..services.signature import decode_rubber_stamp
+
+
+_logger = logging.getLogger("haputele.doctor_onboarding")
+
+router = APIRouter(prefix="/doctor-onboarding", tags=["doctor-onboarding"])
+
+
+# Minimum password length the onboarding flow enforces. Deliberately
+# generous-but-not-stupid: doctors aren't picking these at scale, and
+# very long minimums push them toward writing it down. Tighten later
+# if you add a real password policy elsewhere in the system.
+_MIN_PASSWORD_LEN = 8
+
+
+@router.get("/{token}", response_model=DoctorOnboardingPeek)
+def peek(token: str, db: Session = Depends(db_dep)) -> DoctorOnboardingPeek:
+    """Validate the token and return non-sensitive context for the page.
+
+    Two response shapes by mode:
+      - new      → {mode, email, familyName?}. The frontend renders the
+                   full profile form. Email is shown read-only.
+      - rotation → {mode, email, givenName, familyName}. The frontend
+                   renders the slim password-only form.
+
+    A 404 here means the token is unknown / expired / already consumed —
+    the frontend should render a generic "this link isn't valid" screen.
+    """
+    invite = invites.lookup_live(db, raw_token=token)
+    if invite.doctor_id is None:
+        # New-doctor invite.
+        return DoctorOnboardingPeek(
+            mode="new",
+            email=invite.email,
+            familyName=invite.family_name,
+        )
+    # Rotation invite — Doctor row exists.
+    doctor = db.get(Doctor, invite.doctor_id)
+    if doctor is None:  # extremely unlikely (FK CASCADE) but defensive
+        raise unprocessable("doctor_not_found")
+    return DoctorOnboardingPeek(
+        mode="rotation",
+        email=doctor.email,
+        givenName=doctor.given_name,
+        familyName=doctor.family_name,
+    )
+
+
+@router.post("/{token}", status_code=status.HTTP_204_NO_CONTENT)
+def complete(
+    token: str,
+    payload: dict[str, Any] = Body(...),
+    db: Session = Depends(db_dep),
+) -> Response:
+    """Consume the token. Body shape depends on the invite mode.
+
+    Rotation: {password}. We just set the new password on the existing
+    Account; Doctor row + approval state unchanged.
+
+    New doctor: full DoctorOnboardingSubmit. We create the Account and
+    Doctor row (approved_at = NULL — admin must approve next) and link
+    the invite. Doctor can NOT log in until the admin clicks Approve.
+
+    We dispatch on the actual invite mode (not on the payload shape) so
+    a doctor can't accidentally send a new-doctor payload to a rotation
+    invite or vice versa.
+    """
+    invite = invites.lookup_live(db, raw_token=token)
+    password = payload.get("password") or ""
+    if len(password) < _MIN_PASSWORD_LEN:
+        raise unprocessable("password_too_short", minLength=_MIN_PASSWORD_LEN)
+
+    if invite.doctor_id is not None:
+        # Rotation: ignore anything other than password.
+        doctor = invites.consume_rotation(
+            db, raw_token=token, new_password=password,
+        )
+        _logger.info(
+            "doctor rotation onboarded: doctor_id=%s username=%s",
+            doctor.doctor_id, doctor.username,
+        )
+        return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+    # New-doctor flow: validate the full payload. Email is intentionally
+    # not part of the submission — the invite owns that value.
+    submission = DoctorOnboardingSubmit.model_validate(payload)
+    try:
+        stamp_bytes = decode_rubber_stamp(submission.rubberStampImage)
+    except Exception as exc:
+        raise unprocessable("invalid_rubber_stamp_image", detail=str(exc))
+
+    doctor = invites.consume_new_doctor(
+        db,
+        raw_token=token,
+        username=submission.username.strip(),
+        password=submission.password,
+        profile={
+            "givenName": submission.givenName.strip(),
+            "familyName": submission.familyName.strip(),
+            "contact": submission.contact.strip(),
+            "slmcRegistrationNumber": submission.slmcRegistrationNumber.strip(),
+            "qualifications": submission.qualifications.strip(),
+            "practitionerAddress": submission.practitionerAddress.strip(),
+            "instituteName": submission.instituteName.strip(),
+            "instituteContact": submission.instituteContact.strip(),
+        },
+        rubber_stamp=stamp_bytes,
+    )
+    _logger.info(
+        "new doctor self-onboarded (awaiting approval): doctor_id=%s username=%s",
+        doctor.doctor_id, doctor.username,
+    )
+    return Response(status_code=status.HTTP_204_NO_CONTENT)

--- a/backend/app/routers/doctors.py
+++ b/backend/app/routers/doctors.py
@@ -1,16 +1,80 @@
 import base64
+import logging
+import secrets
 
-from fastapi import APIRouter, Depends, status
+from fastapi import APIRouter, Depends, Response, status
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from datetime import datetime, timezone
+
+from ..config import settings
 from ..deps import db_dep, require_role
-from ..errors import not_found, unprocessable
-from ..models import Account, Doctor
-from ..schemas import DoctorCreate, DoctorDetailOut, DoctorOut, DoctorUpdate
+from ..errors import conflict, not_found, unprocessable
+from ..models import Account, Doctor, DoctorInvite
+from ..schemas import (
+    DoctorCreate,
+    DoctorDetailOut,
+    DoctorInviteCreate,
+    DoctorOut,
+    DoctorRejectIn,
+    DoctorUpdate,
+)
 from ..security import hash_password
+from ..services import doctor_invites as invites
+from ..services.email import is_configured as email_configured, send_templated
 from ..services.signature import decode_rubber_stamp
 from ..services.storage import delete_object, get_bytes, object_key, put_bytes
+
+
+def _doctors_with_live_invite(db: Session, doctor_ids: list[int]) -> set[int]:
+    """Single query: which of these doctor_ids have a live unconsumed invite?
+
+    A "live" invite is `consumed_at IS NULL AND expires_at > NOW()`. Used by
+    list_doctors to compute onboardingStatus without N+1, and by the detail
+    endpoint as a degenerate single-element case.
+    """
+    if not doctor_ids:
+        return set()
+    rows = db.scalars(
+        select(DoctorInvite.doctor_id)
+        .where(
+            DoctorInvite.doctor_id.in_(doctor_ids),
+            DoctorInvite.consumed_at.is_(None),
+            DoctorInvite.expires_at > datetime.now(timezone.utc),
+        )
+        .distinct()
+    ).all()
+    return set(rows)
+
+
+def _onboarding_status(doctor: Doctor, *, has_live_invite: bool) -> str:
+    """Resolve the 4-way status from Doctor row state + invite liveness.
+
+    Priority (top wins): rejected > awaiting_setup (live invite + no row-
+    completion) > awaiting_approval (row exists but unapproved) > active.
+
+    Note: a doctor in the new-doctor flow has `approved_at IS NULL` AND
+    has consumed their invite by the time we look. A doctor in the
+    rotation flow has `approved_at` populated (backfilled by 0010 for
+    pre-existing rows, or set by the legacy POST /doctors path which
+    auto-approves).
+    """
+    if doctor.rejected_at is not None:
+        return "rejected"
+    if has_live_invite:
+        return "awaiting_setup"
+    if doctor.approved_at is None:
+        return "awaiting_approval"
+    return "active"
+
+
+def _attach_status(out: DoctorOut, doctor: Doctor, *, has_live_invite: bool) -> DoctorOut:
+    out.onboardingStatus = _onboarding_status(doctor, has_live_invite=has_live_invite)
+    return out
+
+
+_logger = logging.getLogger("haputele.doctors")
 
 
 router = APIRouter(prefix="/doctors", tags=["doctors"])
@@ -44,6 +108,17 @@ def _encode_stamp(data: bytes | None) -> str | None:
 @router.post("", response_model=DoctorOut, status_code=status.HTTP_201_CREATED,
              dependencies=[Depends(require_role("admin"))])
 def create_doctor(payload: DoctorCreate, db: Session = Depends(db_dep)) -> DoctorOut:
+    """Legacy admin-fills-everything path. Two sub-modes by `password`:
+
+      password set    → admin types the password and shares it offline.
+      password absent → password-rotation invite goes out to the doctor's
+                        email so they can pick a password without admin
+                        ever seeing it. Requires email_configured().
+
+    Doctor is auto-approved on this path — the admin typed every field
+    themselves so there's nothing to review. For the "doctor fills
+    everything" path use POST /doctors/invites instead.
+    """
     missing = [f for f in REQUIRED_PRESCRIPTION_FIELDS if not getattr(payload, f, None)]
     if missing:
         raise unprocessable("missing_prescription_fields", missing=missing)
@@ -51,14 +126,23 @@ def create_doctor(payload: DoctorCreate, db: Session = Depends(db_dep)) -> Docto
     if db.get(Account, payload.username):
         raise unprocessable("username_taken")
 
+    invite_mode = not payload.password
+    if invite_mode and not email_configured():
+        raise unprocessable("email_not_configured")
+
     stamp = decode_rubber_stamp(payload.rubberStampImage)
     mime, ext = _sniff_stamp(stamp)
     stamp_key = object_key("doctors/stamps", ext)
     put_bytes(stamp_key, stamp, mime)
 
+    # In invite mode, generate a random password that's effectively
+    # un-guessable. The doctor will replace it via the onboarding flow;
+    # the value never leaves this function (no log, no return).
+    initial_password = payload.password or secrets.token_urlsafe(48)
+
     account = Account(
         username=payload.username,
-        password=hash_password(payload.password),
+        password=hash_password(initial_password),
         role="doctor",
     )
     doctor = Doctor(
@@ -74,22 +158,258 @@ def create_doctor(payload: DoctorCreate, db: Session = Depends(db_dep)) -> Docto
         institute_contact=payload.instituteContact,
         rubber_stamp_key=stamp_key,
         active=True,
+        # Legacy path is auto-approved — admin typed every field, there's
+        # nothing to review.
+        approved_at=datetime.now(timezone.utc),
     )
     db.add(account)
     db.add(doctor)
     db.commit()
     db.refresh(doctor)
-    return DoctorOut.model_validate(doctor)
+
+    if invite_mode:
+        _send_invite(db, doctor)
+
+    out = DoctorOut.model_validate(doctor)
+    return _attach_status(out, doctor, has_live_invite=invite_mode)
+
+
+@router.post("/{doctor_id}/invites", status_code=status.HTTP_204_NO_CONTENT,
+             dependencies=[Depends(require_role("admin"))])
+def reissue_invite(doctor_id: int, db: Session = Depends(db_dep)) -> Response:
+    """Issue a fresh password-rotation invite for an existing doctor.
+
+    Used when the original link expired, was lost, or the doctor's email
+    address has been corrected. Any prior live invite for the same
+    doctor is revoked inside `invites.issue_rotation()`.
+    """
+    if not email_configured():
+        raise unprocessable("email_not_configured")
+    doctor = db.get(Doctor, doctor_id)
+    if doctor is None:
+        raise not_found("doctor_not_found")
+    _send_invite(db, doctor)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+@router.post("/invites", status_code=status.HTTP_201_CREATED,
+             dependencies=[Depends(require_role("admin"))])
+def invite_new_doctor(
+    payload: DoctorInviteCreate, db: Session = Depends(db_dep),
+) -> dict:
+    """Email-only invite: admin types just the doctor's email, the
+    doctor fills out their full profile via the onboarding link.
+
+    The Doctor row is NOT created here — it springs into existence when
+    the doctor consumes the invite. The admin then sees it in their
+    "awaiting approval" queue and approves or rejects.
+
+    Refuses (409 `email_already_used`) if the address is already in use
+    by an existing doctor or has a separate live invite.
+    """
+    if not email_configured():
+        raise unprocessable("email_not_configured")
+    invite, raw_token = invites.issue_new_doctor(
+        db, email=payload.email, family_name=payload.familyName,
+    )
+    link = invites.build_invite_link(raw_token)
+    try:
+        msg_id = send_templated(
+            db,
+            to=invite.email,
+            subject="You're invited to HapuTele",
+            template="doctor_invite",
+            context={
+                "mode": "new",
+                # Hint only — may be None. The template falls back to
+                # "Hi there," when absent.
+                "family_name": invite.family_name,
+                "link": link,
+                "expires_hours": int(
+                    (invite.expires_at - invite.created_at).total_seconds() // 3600
+                ),
+            },
+            tags={"kind": "doctor.invite.new", "invite_id": str(invite.id)},
+        )
+        _logger.info(
+            "new-doctor invite sent: email=%s invite_id=%s msg_id=%s",
+            invite.email, invite.id, msg_id,
+        )
+    except Exception:
+        _logger.exception(
+            "new-doctor invite email failed (invite row %s still issued): email=%s",
+            invite.id, invite.email,
+        )
+    return {"inviteId": invite.id, "email": invite.email}
+
+
+@router.post("/{doctor_id}/approve", response_model=DoctorOut,
+             dependencies=[Depends(require_role("admin"))])
+def approve_doctor(doctor_id: int, db: Session = Depends(db_dep)) -> DoctorOut:
+    """Approve a self-onboarded doctor. Idempotent — re-calling after
+    approval is a no-op that still returns the current state.
+
+    Rejecting a previously-rejected doctor first requires clearing
+    rejected_at (the frontend's "Re-open this submission" path), so this
+    endpoint refuses (409 `doctor_rejected`) until that's done."""
+    doctor = db.get(Doctor, doctor_id)
+    if doctor is None:
+        raise not_found("doctor_not_found")
+    if doctor.rejected_at is not None:
+        raise conflict("doctor_rejected")
+    # Only send the notification email on the actual NULL→approved
+    # transition. Repeat approval calls are no-ops at the DB level AND
+    # at the email level, so a fat-fingered double-click doesn't ping
+    # the doctor twice.
+    just_approved = doctor.approved_at is None
+    if just_approved:
+        doctor.approved_at = datetime.now(timezone.utc)
+        db.commit()
+        db.refresh(doctor)
+        _send_approval_notification(db, doctor)
+    _logger.info("doctor approved: id=%s username=%s", doctor_id, doctor.username)
+    out = DoctorOut.model_validate(doctor)
+    has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
+    return _attach_status(out, doctor, has_live_invite=has_live)
+
+
+def _send_approval_notification(db: Session, doctor: Doctor) -> None:
+    """Dispatch the "your account is ready" email. Best-effort: a Resend
+    failure here is logged but does NOT roll back the approval. The
+    admin sees the doctor as approved either way; the doctor either gets
+    the email or (worst case) finds out the next time they try to log in.
+
+    Skipped silently if the email service isn't configured — the admin
+    is still in the loop and can tell the doctor by other means.
+    """
+    if not email_configured():
+        _logger.info(
+            "approval email skipped (email_not_configured): doctor_id=%s",
+            doctor.doctor_id,
+        )
+        return
+    login_link = f"{settings.FRONTEND_BASE_URL or ''}/login"
+    try:
+        msg_id = send_templated(
+            db,
+            to=doctor.email,
+            subject="Your HapuTele account is approved",
+            template="doctor_approved",
+            context={
+                "family_name": doctor.family_name,
+                "login_link": login_link,
+            },
+            tags={"kind": "doctor.approved", "doctor_id": str(doctor.doctor_id)},
+            # Same approval can't be triggered twice (NULL→ts is the
+            # state change we guard on), but pass an idempotency key
+            # anyway for symmetry with the invite path. If approval is
+            # ever moved to an at-least-once delivery (job queue), the
+            # key remains the right uniqueness token at Resend.
+            idempotency_key=f"doctor.approved:doctor-{doctor.doctor_id}",
+        )
+        _logger.info(
+            "doctor approval email sent: doctor_id=%s msg_id=%s",
+            doctor.doctor_id, msg_id,
+        )
+    except Exception:
+        _logger.exception(
+            "doctor approval email failed (doctor still approved): doctor_id=%s",
+            doctor.doctor_id,
+        )
+
+
+@router.post("/{doctor_id}/reject", response_model=DoctorOut,
+             dependencies=[Depends(require_role("admin"))])
+def reject_doctor(
+    doctor_id: int,
+    payload: DoctorRejectIn,
+    db: Session = Depends(db_dep),
+) -> DoctorOut:
+    """Reject a self-onboarded doctor. Stamps rejected_at +
+    rejected_reason and deactivates so they can't log in.
+
+    Refuses (409 `doctor_already_approved`) if the doctor is already
+    approved — admin should deactivate via the normal DELETE path instead
+    so the audit trail stays clean ("rejected" specifically means the
+    onboarding submission was bad).
+    """
+    doctor = db.get(Doctor, doctor_id)
+    if doctor is None:
+        raise not_found("doctor_not_found")
+    if doctor.approved_at is not None:
+        raise conflict("doctor_already_approved")
+    doctor.rejected_at = datetime.now(timezone.utc)
+    doctor.rejected_reason = (payload.reason or "").strip() or None
+    doctor.active = False
+    db.commit()
+    db.refresh(doctor)
+    _logger.info(
+        "doctor rejected: id=%s username=%s reason=%r",
+        doctor_id, doctor.username, doctor.rejected_reason,
+    )
+    out = DoctorOut.model_validate(doctor)
+    has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
+    return _attach_status(out, doctor, has_live_invite=has_live)
+
+
+def _send_invite(db: Session, doctor: Doctor) -> None:
+    """Issue an invite row and dispatch the email. Logs but doesn't raise
+    on Resend failure — the admin has already gotten a 201 for the
+    create, and the invite row exists for re-send."""
+    invite, raw_token = invites.issue_rotation(db, doctor_id=doctor.doctor_id)
+    link = invites.build_invite_link(raw_token)
+    try:
+        msg_id = send_templated(
+            db,
+            to=doctor.email,
+            subject="Set your password",
+            template="doctor_invite",
+            context={
+                "mode": "rotation",
+                "family_name": doctor.family_name,
+                "link": link,
+                "expires_hours": int(
+                    (invite.expires_at - invite.created_at).total_seconds() // 3600
+                ),
+            },
+            tags={"kind": "doctor.invite", "doctor_id": str(doctor.doctor_id)},
+        )
+        _logger.info(
+            "doctor invite sent: doctor_id=%s email=%s msg_id=%s",
+            doctor.doctor_id, doctor.email, msg_id,
+        )
+    except Exception:
+        _logger.exception(
+            "doctor invite email failed (invite row %s still issued): doctor_id=%s",
+            invite.id, doctor.doctor_id,
+        )
 
 
 @router.get("", response_model=list[DoctorOut])
 def list_doctors(active: bool | None = None, db: Session = Depends(db_dep),
-                 _user=Depends(require_role("admin", "doctor", "healthworker"))):
+                 user=Depends(require_role("admin", "doctor", "healthworker"))):
     stmt = select(Doctor)
     if active is not None:
         stmt = stmt.where(Doctor.active.is_(active))
+    # Healthworkers (booking flow) and doctors (browsing colleagues) only
+    # ever see approved, non-rejected doctors. Admins see everyone,
+    # including awaiting_approval and rejected entries, so they can act
+    # on them.
+    if user.role != "admin":
+        stmt = stmt.where(
+            Doctor.approved_at.is_not(None),
+            Doctor.rejected_at.is_(None),
+        )
     rows = db.scalars(stmt.order_by(Doctor.doctor_id)).all()
-    return [DoctorOut.model_validate(r) for r in rows]
+    # Two queries total: the doctor list, then a single batched lookup of
+    # "which of these have a live invite". O(1) regardless of doctor count.
+    awaiting_ids = _doctors_with_live_invite(db, [r.doctor_id for r in rows])
+    return [
+        _attach_status(
+            DoctorOut.model_validate(r), r, has_live_invite=r.doctor_id in awaiting_ids,
+        )
+        for r in rows
+    ]
 
 
 @router.get("/{doctor_id}", response_model=DoctorDetailOut,
@@ -100,7 +420,8 @@ def get_doctor(doctor_id: int, db: Session = Depends(db_dep)) -> DoctorDetailOut
         raise not_found("doctor_not_found")
     out = DoctorDetailOut.model_validate(doctor)
     out.rubberStampImage = _encode_stamp(get_bytes(doctor.rubber_stamp_key))
-    return out
+    has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
+    return _attach_status(out, doctor, has_live_invite=has_live)
 
 
 @router.patch("/{doctor_id}", response_model=DoctorOut,
@@ -153,7 +474,9 @@ def update_doctor(doctor_id: int, payload: DoctorUpdate, db: Session = Depends(d
     # commit rolls back to old_key, so we must not delete it pre-commit.
     if superseded_key:
         delete_object(superseded_key)
-    return DoctorOut.model_validate(doctor)
+    out = DoctorOut.model_validate(doctor)
+    has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
+    return _attach_status(out, doctor, has_live_invite=has_live)
 
 
 @router.delete("/{doctor_id}", status_code=status.HTTP_204_NO_CONTENT,

--- a/backend/app/routers/resend_webhook.py
+++ b/backend/app/routers/resend_webhook.py
@@ -1,0 +1,117 @@
+"""Resend webhook handler — maintains the email suppression list.
+
+Resend POSTs delivery events (`email.delivered`, `email.bounced`,
+`email.complained`, `email.opened`, …) signed with Svix. We verify
+the signature with the Svix SDK, then act on the two events that
+affect future sends:
+
+  email.bounced (type == "hard")  → suppress the address
+  email.complained                → suppress the address
+
+Soft bounces are ignored — they're typically transient mailbox-full
+/ greylisting. Other events (delivered, opened, clicked) we accept
+and log so the request gets a 204 and Resend stops retrying.
+
+The endpoint is intentionally unauthenticated (no session cookie,
+no CSRF) — Resend is the only valid caller and the Svix signature
+is the only credential that matters. The setup gate whitelists
+`/resend/webhook` so retries before first-run setup don't pile up
+as 409s.
+"""
+from __future__ import annotations
+
+import json
+import logging
+
+from fastapi import APIRouter, Depends, Header, Request, Response
+from sqlalchemy.orm import Session
+from svix.webhooks import Webhook, WebhookVerificationError
+
+from ..config import settings
+from ..deps import db_dep
+from ..errors import unauthorized, unprocessable
+from ..services.email import suppress
+
+
+_logger = logging.getLogger("haputele.resend_webhook")
+
+router = APIRouter(prefix="/resend", tags=["resend"])
+
+
+@router.post("/webhook")
+async def resend_webhook(
+    request: Request,
+    svix_id: str | None = Header(default=None, alias="svix-id"),
+    svix_timestamp: str | None = Header(default=None, alias="svix-timestamp"),
+    svix_signature: str | None = Header(default=None, alias="svix-signature"),
+    db: Session = Depends(db_dep),
+) -> Response:
+    if not settings.RESEND_WEBHOOK_SECRET:
+        # Receiving a webhook with no configured secret means either the
+        # URL leaked or an operator forgot to set the secret — refuse
+        # rather than no-op silently and have events disappear.
+        raise unprocessable("resend_webhook_not_configured")
+    if not (svix_id and svix_timestamp and svix_signature):
+        raise unauthorized("missing_svix_headers")
+
+    body = await request.body()
+    headers = {
+        "svix-id": svix_id,
+        "svix-timestamp": svix_timestamp,
+        "svix-signature": svix_signature,
+    }
+    try:
+        wh = Webhook(settings.RESEND_WEBHOOK_SECRET)
+        wh.verify(body, headers)
+    except WebhookVerificationError as exc:
+        _logger.warning("resend webhook rejected: %s", exc)
+        raise unauthorized("invalid_webhook_signature")
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except json.JSONDecodeError:
+        # Signature was valid but body isn't JSON — shouldn't happen,
+        # but ack with 204 so Resend stops retrying a broken event.
+        _logger.warning("resend webhook: signature ok but body not JSON")
+        return Response(status_code=204)
+
+    event_type = payload.get("type") or ""
+    data = payload.get("data") or {}
+
+    if event_type == "email.bounced":
+        # `bounce.type` is "hard" | "soft" | "undetermined". Only hard
+        # bounces are suppressed — soft bounces (mailbox full, temp DNS
+        # failure) often recover and aren't worth permanent blocklisting.
+        bounce_type = (data.get("bounce") or {}).get("type", "")
+        if bounce_type == "hard":
+            for addr in _recipients(data):
+                suppress(
+                    db,
+                    email=addr,
+                    reason="bounced.hard",
+                    detail={"bounce": data.get("bounce") or {}},
+                )
+        else:
+            _logger.info("resend bounce ignored (type=%r)", bounce_type)
+    elif event_type == "email.complained":
+        for addr in _recipients(data):
+            suppress(db, email=addr, reason="complained", detail={})
+    else:
+        _logger.debug("resend event accepted-and-ignored: %s", event_type)
+
+    return Response(status_code=204)
+
+
+def _recipients(data: dict) -> list[str]:
+    """Pull recipient addresses out of a Resend event payload.
+
+    Resend's event `data.to` is a list of strings; older payloads or
+    edge events sometimes use a bare string — accept both so a schema
+    drift doesn't silently break suppression.
+    """
+    to = data.get("to")
+    if isinstance(to, str):
+        return [to]
+    if isinstance(to, list):
+        return [t for t in to if isinstance(t, str)]
+    return []

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -48,7 +48,76 @@ class DoctorBase(BaseModel):
 
 class DoctorCreate(DoctorBase):
     username: str
+    # Optional — if omitted/empty, the system creates the account with a
+    # random password and emails the doctor an invite link to set their
+    # own. Requires the email service to be configured; the endpoint will
+    # 422 `email_not_configured` otherwise.
+    password: Optional[str] = None
+
+
+class DoctorOnboardingPeek(BaseModel):
+    """Public view returned when a doctor visits an invite link.
+
+    `mode` distinguishes the two invite shapes:
+      - "new"      → the doctor is onboarding fresh. Frontend renders the
+                     full profile form; email + familyName are shown read-only
+                     as part of the welcome.
+      - "rotation" → an existing doctor is just setting a new password.
+                     Frontend renders the slim password-only form.
+    """
+    mode: str  # "new" | "rotation"
+    email: str
+    # Populated in "new" mode when the admin supplied a family-name hint
+    # at invite time, and in "rotation" mode from the existing Doctor row.
+    familyName: str | None = None
+    givenName: str | None = None  # only in rotation mode
+
+
+class DoctorOnboardingComplete(BaseModel):
+    """Rotation-flow payload — just a new password."""
     password: str
+
+
+class DoctorOnboardingSubmit(BaseModel):
+    """New-doctor payload — full profile + chosen credentials.
+
+    Note: there is deliberately NO email field. The invite already binds
+    an email address; the server uses that value when creating the
+    Account + Doctor row and ignores anything the client might send.
+    This makes the "doctor submitted a different email" case
+    unrepresentable rather than something we'd need to validate against.
+
+    Server validates §1.7 mandatory fields are present. RubberStampImage
+    is a base64 data URL (the same shape the admin form already uses).
+    """
+    username: str
+    password: str
+    givenName: str
+    familyName: str
+    contact: str
+    slmcRegistrationNumber: str
+    qualifications: str
+    practitionerAddress: str
+    instituteName: str
+    instituteContact: str
+    rubberStampImage: str  # base64
+
+
+class DoctorInviteCreate(BaseModel):
+    """Admin's invite-by-email request. Only the email is required.
+
+    `familyName` is an optional hint solely for the invite email's
+    greeting — the doctor's real family name is captured during
+    onboarding. Not echoed in any later API response.
+    """
+    email: EmailStr
+    familyName: str | None = None
+
+
+class DoctorRejectIn(BaseModel):
+    """Admin's reject payload. `reason` is shown to the doctor on a
+    pending/rejected screen and stored on the Doctor row for audit."""
+    reason: str | None = None
 
 
 class DoctorUpdate(BaseModel):
@@ -81,6 +150,19 @@ class DoctorOut(BaseModel):
     instituteName: str = Field(validation_alias="institute_name")
     instituteContact: str = Field(validation_alias="institute_contact")
     active: bool
+    # Three-state lifecycle:
+    #   "awaiting_setup"    → live unconsumed invite, doctor hasn't filled
+    #                         out the form yet (or has filled it out and
+    #                         submitted but their row hasn't been created
+    #                         yet — only possible in the legacy mode).
+    #   "awaiting_approval" → doctor has submitted their profile; admin
+    #                         hasn't approved yet. Account exists but
+    #                         can't log in.
+    #   "rejected"          → admin reviewed + rejected. active is also
+    #                         false; rejected_at + rejected_reason are
+    #                         populated on the Doctor row.
+    #   "active"            → approved + onboarded. Normal state.
+    onboardingStatus: str = "active"
 
 
 class DoctorDetailOut(DoctorOut):

--- a/backend/app/scripts/demo_invite.py
+++ b/backend/app/scripts/demo_invite.py
@@ -1,0 +1,155 @@
+"""One-shot demo seeder for the doctor-onboarding flow.
+
+Usage (from inside the api container):
+
+    docker compose exec api python -m app.scripts.demo_invite <doctor_email>
+
+Steps it performs, all idempotent:
+
+  1. Verifies system_config.initialized_at IS NOT NULL. If the wizard
+     hasn't been run yet, exits 1 with a hint to visit /setup first.
+  2. Upserts a `demo_admin / demo-admin-pass` admin account so the
+     operator can log in and exercise the re-issue button later.
+  3. Upserts a `demo_doctor` Doctor row with the email argument and
+     an unguessable random password.
+  4. Issues a fresh DoctorInvite (revoking any prior live one for that
+     doctor), sends the templated invite email via Resend, prints both
+     the recipient and the raw URL so the operator can click the link
+     without waiting for inbox delivery.
+
+Requires RESEND_API_KEY + RESEND_FROM + FRONTEND_BASE_URL to be set;
+emits a clear error message if any of them is missing rather than
+silently failing inside Resend.
+"""
+from __future__ import annotations
+
+import argparse
+import secrets
+import sys
+
+from app.database import SessionLocal
+from app.models import Account, Doctor
+from app.security import hash_password
+from app.services import doctor_invites as invites
+from app.services.email import is_configured, send_templated
+from app.services.system_config import get_system_config, load_system_config
+
+
+_DEMO_ADMIN_USERNAME = "demo_admin"
+_DEMO_ADMIN_PASSWORD = "demo-admin-pass"  # only used in local demos
+_DEMO_DOCTOR_USERNAME = "demo_doctor"
+
+
+def _ensure_admin(db) -> None:
+    if db.get(Account, _DEMO_ADMIN_USERNAME):
+        print(f"  ✓ admin already exists: {_DEMO_ADMIN_USERNAME}")
+        return
+    db.add(Account(
+        username=_DEMO_ADMIN_USERNAME,
+        password=hash_password(_DEMO_ADMIN_PASSWORD),
+        role="admin",
+    ))
+    db.commit()
+    print(f"  ✓ created admin: {_DEMO_ADMIN_USERNAME} / {_DEMO_ADMIN_PASSWORD}")
+
+
+def _ensure_doctor(db, *, email: str) -> Doctor:
+    existing = db.query(Doctor).filter_by(username=_DEMO_DOCTOR_USERNAME).first()
+    if existing:
+        # Update the email in case the operator wants to re-run with a
+        # different recipient (e.g. testing a colleague's address).
+        if existing.email != email:
+            existing.email = email
+            db.commit()
+            print(f"  ✓ updated existing doctor email → {email}")
+        else:
+            print(f"  ✓ doctor already exists: {_DEMO_DOCTOR_USERNAME} (email={email})")
+        return existing
+
+    db.add(Account(
+        username=_DEMO_DOCTOR_USERNAME,
+        password=hash_password(secrets.token_urlsafe(48)),
+        role="doctor",
+    ))
+    db.add(Doctor(
+        username=_DEMO_DOCTOR_USERNAME,
+        given_name="Demo", family_name="Doctor",
+        contact="+94 11 000 0000", email=email,
+        slmc_registration_number="SLMC-DEMO", qualifications="MBBS",
+        practitioner_address="Demo Address",
+        institute_name="Demo Clinic", institute_contact="+94 11 111 1111",
+        rubber_stamp_image=b"\x89PNG\r\n\x1a\n", active=True,
+    ))
+    db.commit()
+    doctor = db.query(Doctor).filter_by(username=_DEMO_DOCTOR_USERNAME).first()
+    print(f"  ✓ created doctor: {_DEMO_DOCTOR_USERNAME} (id={doctor.doctor_id}, email={email})")
+    return doctor
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("email", help="Doctor's email address (recipient of the invite)")
+    args = parser.parse_args(argv)
+
+    db = SessionLocal()
+    try:
+        load_system_config(db)
+        if not get_system_config().is_initialized:
+            print(
+                "ERROR: system_config not initialized. Walk through the /setup "
+                "wizard first (visit http://localhost:3000/setup and use the "
+                "token printed in the api container logs).",
+                file=sys.stderr,
+            )
+            return 1
+
+        if not is_configured():
+            print(
+                "ERROR: email service not configured. Set RESEND_API_KEY and "
+                "RESEND_FROM in the project-root .env, then `docker compose up`.",
+                file=sys.stderr,
+            )
+            return 1
+
+        print("Seeding demo accounts:")
+        _ensure_admin(db)
+        doctor = _ensure_doctor(db, email=args.email)
+
+        print()
+        print("Issuing invite + sending email…")
+        invite, raw = invites.issue(db, doctor_id=doctor.doctor_id)
+        link = invites.build_invite_link(raw)
+        msg_id = send_templated(
+            db,
+            to=doctor.email,
+            subject="Set your password",
+            template="doctor_invite",
+            context={
+                "mode": "rotation",
+                "family_name": doctor.family_name,
+                "link": link,
+                "expires_hours": int(
+                    (invite.expires_at - invite.created_at).total_seconds() // 3600
+                ),
+            },
+            tags={"kind": "doctor.invite", "doctor_id": str(doctor.doctor_id)},
+        )
+        print(f"  ✓ Resend message id: {msg_id}")
+        print(f"  ✓ recipient: {doctor.email}")
+        print()
+        print("=" * 70)
+        print("If you don't want to wait for the email, click this link directly:")
+        print()
+        print(f"  {link}")
+        print()
+        print("Admin credentials for re-issue testing:")
+        print(f"  username: {_DEMO_ADMIN_USERNAME}")
+        print(f"  password: {_DEMO_ADMIN_PASSWORD}")
+        print("=" * 70)
+        return 0
+    finally:
+        db.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/app/services/doctor_invites.py
+++ b/backend/app/services/doctor_invites.py
@@ -1,0 +1,282 @@
+"""Issue, consume, and re-issue doctor onboarding tokens.
+
+Two invite shapes share this table:
+
+  rotation: doctor_id is set, the Doctor row already exists, and the
+            invite is just a way for the doctor to choose a new password.
+            email is also set (copied from the doctor row) so the same
+            "you can't double-invite the same address" guard works.
+
+  new:      doctor_id is NULL until the invite is consumed. The admin
+            captured only the email (+ optional family_name greeting
+            hint). On consume() we create the Account + Doctor row with
+            approved_at NULL, link the invite to the new doctor_id, and
+            mark consumed. The Doctor row appears in the admin's "awaiting
+            approval" queue rather than being immediately usable.
+
+Token format: `secrets.token_urlsafe(32)` → ~43 chars of URL-safe base64.
+We store sha256-hex of the raw token; the raw value goes out exactly
+once in the invite email and is never persisted server-side. This is the
+same pattern as setup_tokens (see alembic 0006).
+
+Liveness: a row is "live" iff `consumed_at IS NULL AND expires_at > NOW()`.
+Re-issuing supersedes any earlier live invite for the same target (same
+doctor_id for rotation, same email for new) by stamping consumed_at —
+keeps audit trail intact while ensuring that a leaked older link can't
+be used after rotation.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+from urllib.parse import quote
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..errors import conflict, not_found, unprocessable
+from ..models import Account, Doctor, DoctorInvite
+from ..security import hash_password
+from .storage import object_key, put_bytes
+
+
+def _sniff_stamp(data: bytes) -> tuple[str, str]:
+    """(mime, ext) from magic bytes — PNG/JPEG only, mirrors the helper
+    in routers/doctors.py. Inline to avoid services→routers import."""
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg", "jpg"
+    return "image/png", "png"
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def issue_rotation(db: Session, *, doctor_id: int) -> tuple[DoctorInvite, str]:
+    """Rotation mode: mint a new password-reset invite for an existing
+    doctor. Returns (row, raw_token).
+
+    The raw token is what goes in the email link. The row is committed so
+    the caller can reference its id in logs. Any prior live invites for
+    this doctor are revoked so only the newest link works.
+    """
+    doctor = db.get(Doctor, doctor_id)
+    if doctor is None:
+        raise not_found("doctor_not_found")
+
+    now = datetime.now(timezone.utc)
+    _revoke_live_invites(db, doctor_id=doctor_id, email=doctor.email, now=now)
+
+    raw = secrets.token_urlsafe(32)
+    ttl = timedelta(hours=settings.DOCTOR_INVITE_TTL_HOURS)
+    invite = DoctorInvite(
+        doctor_id=doctor_id,
+        email=doctor.email,
+        family_name=doctor.family_name,
+        token_hash=_hash(raw),
+        expires_at=now + ttl,
+    )
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+    return invite, raw
+
+
+def issue_new_doctor(
+    db: Session, *, email: str, family_name: str | None = None,
+) -> tuple[DoctorInvite, str]:
+    """New mode: mint an invite for a doctor who doesn't have a row yet.
+
+    Refuses (409 `email_already_used`) if the email is already linked to
+    a Doctor row OR has another live unconsumed new-doctor invite. The
+    second check is the cheap way to prevent two admins from inviting
+    the same address twice in parallel; we revoke prior live invites for
+    the same email on the happy path below.
+    """
+    normalised = email.strip().lower()
+
+    # Already-a-doctor check.
+    if db.scalar(select(Doctor).where(Doctor.email == normalised)):
+        raise conflict("email_already_used")
+
+    now = datetime.now(timezone.utc)
+    # Revoke any still-live invites for this email (whether rotation or
+    # new) before issuing fresh. Operators sometimes click "resend" twice
+    # quickly; the old link should stop working.
+    _revoke_live_invites(db, doctor_id=None, email=normalised, now=now)
+
+    raw = secrets.token_urlsafe(32)
+    ttl = timedelta(hours=settings.DOCTOR_INVITE_TTL_HOURS)
+    invite = DoctorInvite(
+        doctor_id=None,
+        email=normalised,
+        family_name=family_name.strip() if family_name else None,
+        token_hash=_hash(raw),
+        expires_at=now + ttl,
+    )
+    db.add(invite)
+    db.commit()
+    db.refresh(invite)
+    return invite, raw
+
+
+def _revoke_live_invites(
+    db: Session, *, doctor_id: int | None, email: str, now: datetime,
+) -> None:
+    """Mark every still-live invite that matches this target as consumed.
+
+    Matches by doctor_id when provided AND by email — keeps either side
+    of the (rotation, new) dichotomy from leaking links across the
+    boundary if an operator switches modes for the same address.
+    """
+    stmt = select(DoctorInvite).where(
+        DoctorInvite.consumed_at.is_(None),
+        DoctorInvite.expires_at > now,
+    )
+    if doctor_id is not None:
+        stmt = stmt.where(
+            (DoctorInvite.doctor_id == doctor_id) | (DoctorInvite.email == email)
+        )
+    else:
+        stmt = stmt.where(DoctorInvite.email == email)
+    for row in db.scalars(stmt).all():
+        row.consumed_at = now
+
+
+def lookup_live(db: Session, *, raw_token: str) -> DoctorInvite:
+    """Resolve a raw token to its DoctorInvite row, asserting liveness.
+
+    Raises 404 `invite_not_found` for any of: unknown token, already
+    consumed, expired. We deliberately don't distinguish between those
+    in the user-facing error so an attacker can't probe for the
+    consumption state of arbitrary tokens.
+    """
+    row = db.scalar(
+        select(DoctorInvite).where(DoctorInvite.token_hash == _hash(raw_token))
+    )
+    now = datetime.now(timezone.utc)
+    if row is None or row.consumed_at is not None or row.expires_at <= now:
+        raise not_found("invite_not_found")
+    return row
+
+
+def consume_rotation(db: Session, *, raw_token: str, new_password: str) -> Doctor:
+    """Rotation mode: verify token, set the doctor's password, mark consumed.
+
+    Returns the Doctor row so the caller can log who got onboarded.
+    Caller is responsible for any password-policy checks (length etc.)
+    before calling here — we don't make assumptions about local rules.
+    """
+    if not new_password:
+        raise unprocessable("missing_password")
+
+    invite = lookup_live(db, raw_token=raw_token)
+    if invite.doctor_id is None:
+        # The token belongs to a new-doctor invite; call consume_new_doctor.
+        raise unprocessable("wrong_invite_mode")
+    doctor = db.get(Doctor, invite.doctor_id)
+    if doctor is None:
+        # Invite outlived the doctor row (cascaded delete should have
+        # caught this, but defensive in case of admin races).
+        raise not_found("doctor_not_found")
+
+    account = db.get(Account, doctor.username)
+    if account is None:
+        raise not_found("account_not_found")
+
+    account.password = hash_password(new_password)
+    invite.consumed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(doctor)
+    return doctor
+
+
+def consume_new_doctor(
+    db: Session,
+    *,
+    raw_token: str,
+    username: str,
+    password: str,
+    profile: dict,
+    rubber_stamp: bytes,
+) -> Doctor:
+    """New mode: create Account + Doctor from the doctor's submission.
+
+    `profile` carries the §1.7 fields (givenName, familyName, contact,
+    slmcRegistrationNumber, qualifications, practitionerAddress,
+    instituteName, instituteContact). The new Doctor row gets approved_at
+    = NULL so it shows up in the admin's awaiting-approval queue.
+
+    Raises 422 username_taken if `username` is already in use.
+
+    The whole thing happens in one DB commit so a crash between steps
+    can't leave an Account with no Doctor row.
+    """
+    if not password:
+        raise unprocessable("missing_password")
+
+    invite = lookup_live(db, raw_token=raw_token)
+    if invite.doctor_id is not None:
+        raise unprocessable("wrong_invite_mode")
+
+    if db.get(Account, username):
+        raise unprocessable("username_taken")
+
+    # Upload the rubber stamp bytes to S3 first; only the object key
+    # lands on the Doctor row. We commit-then-rollback isn't possible
+    # for the S3 side, but we put before insert so a DB failure leaves
+    # an orphan key (harmless) rather than a Doctor row pointing at a
+    # missing object.
+    mime, ext = _sniff_stamp(rubber_stamp)
+    stamp_key = object_key("doctors/stamps", ext)
+    put_bytes(stamp_key, rubber_stamp, mime)
+
+    account = Account(
+        username=username,
+        password=hash_password(password),
+        role="doctor",
+    )
+    doctor = Doctor(
+        username=username,
+        given_name=profile["givenName"],
+        family_name=profile["familyName"],
+        contact=profile["contact"],
+        email=invite.email,
+        slmc_registration_number=profile["slmcRegistrationNumber"],
+        qualifications=profile["qualifications"],
+        practitioner_address=profile["practitionerAddress"],
+        institute_name=profile["instituteName"],
+        institute_contact=profile["instituteContact"],
+        rubber_stamp_key=stamp_key,
+        active=True,
+        approved_at=None,  # awaits admin approval before login is allowed
+    )
+    db.add(account)
+    db.add(doctor)
+    db.flush()  # populate doctor.doctor_id so we can link the invite
+    invite.doctor_id = doctor.doctor_id
+    invite.consumed_at = datetime.now(timezone.utc)
+    db.commit()
+    db.refresh(doctor)
+    return doctor
+
+
+def build_invite_link(raw_token: str) -> str:
+    """Absolute URL the doctor clicks. Relies on FRONTEND_BASE_URL."""
+    if not settings.FRONTEND_BASE_URL:
+        raise unprocessable("frontend_base_url_not_configured")
+    return f"{settings.FRONTEND_BASE_URL}/doctor-onboarding/{quote(raw_token)}"
+
+
+# Backwards-compat aliases for code paths and tests that pre-date the
+# rotation/new-doctor split. Both forward to the rotation variant since
+# every legacy caller (admin POST /doctors, demo_invite) created the
+# Doctor row first and then issued an invite to set the password.
+def issue(db: Session, *, doctor_id: int) -> tuple[DoctorInvite, str]:
+    return issue_rotation(db, doctor_id=doctor_id)
+
+
+def consume(db: Session, *, raw_token: str, new_password: str) -> Doctor:
+    return consume_rotation(db, raw_token=raw_token, new_password=new_password)

--- a/backend/app/services/email.py
+++ b/backend/app/services/email.py
@@ -1,0 +1,313 @@
+"""Resend transactional email service.
+
+Same shape as services/livekit.py: thin wrapper around the vendor SDK,
+fails loudly with a 422 when not configured so callers can branch on
+the standard error envelope. There is no fallback transport — if
+RESEND_API_KEY is empty we treat the system as "email disabled" and
+let callers decide whether that's an error or a soft-skip.
+
+Configuration states:
+
+    RESEND_API_KEY="" → is_configured() == False.
+        send_email() raises 422 email_not_configured. Tests and dev
+        environments without a Resend account hit this branch.
+
+    RESEND_API_KEY=set, RESEND_FROM=onboarding@resend.dev → dev mode.
+        Resend will only deliver to the email registered on the
+        account; everything else is silently dropped on their side.
+        We don't enforce that here — operators flipping to a real
+        FROM = the only correct step.
+
+    RESEND_API_KEY=set, RESEND_FROM=verified domain → prod mode.
+
+Suppression: every send_email() call first checks email_suppressions.
+Addresses recorded there (by the webhook handler on hard bounce /
+complaint) are skipped silently and the function returns `None`.
+Callers wanting send-or-fail semantics for critical mail (password
+reset) should check the return value.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+import resend
+from jinja2 import Environment, FileSystemLoader, StrictUndefined, select_autoescape
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..config import settings
+from ..errors import unprocessable
+from ..models import EmailSuppression
+
+
+_logger = logging.getLogger("haputele.email")
+
+
+# Jinja2 environment, configured once at import time. StrictUndefined turns
+# typos in template variables into immediate exceptions instead of silently
+# rendering blanks — easier to catch in tests than in production. Autoescape
+# is on for .html only; .txt templates render literally.
+_TEMPLATE_DIR = Path(__file__).resolve().parent.parent / "templates" / "email"
+_jinja = Environment(
+    loader=FileSystemLoader(str(_TEMPLATE_DIR)),
+    autoescape=select_autoescape(["html", "htm"]),
+    undefined=StrictUndefined,
+    trim_blocks=True,
+    lstrip_blocks=True,
+)
+
+
+def is_configured() -> bool:
+    return bool(settings.RESEND_API_KEY and settings.RESEND_FROM)
+
+
+def _normalize(addr: str) -> str:
+    return addr.strip().lower()
+
+
+_TAG_ALLOWED = set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+
+
+def _sanitize_tag(value: str) -> str:
+    """Replace characters Resend's tag validator rejects with underscores."""
+    return "".join(c if c in _TAG_ALLOWED else "_" for c in str(value))
+
+
+def _filter_suppressed(db: Session, addresses: Iterable[str]) -> tuple[list[str], list[str]]:
+    """Split `addresses` into (sendable, suppressed). Both lowercased."""
+    lowered = [_normalize(a) for a in addresses if a]
+    if not lowered:
+        return [], []
+    rows = db.execute(
+        select(EmailSuppression.email).where(EmailSuppression.email.in_(lowered))
+    ).all()
+    suppressed = {r[0] for r in rows}
+    sendable = [a for a in lowered if a not in suppressed]
+    return sendable, sorted(suppressed)
+
+
+def send_email(
+    db: Session,
+    *,
+    to: str | list[str],
+    subject: str,
+    html: str,
+    text: str | None = None,
+    tags: dict[str, str] | None = None,
+    scheduled_at: "datetime | None" = None,
+    idempotency_key: str | None = None,
+) -> str | None:
+    """Send a transactional email via Resend.
+
+    Returns the Resend message id on success, or `None` if every
+    requested recipient was on the suppression list (the call was a
+    no-op). Raises 422 `email_not_configured` if RESEND_API_KEY or
+    RESEND_FROM are unset.
+
+    Optional parameters:
+
+      scheduled_at: datetime in any timezone. Resend holds the email
+        until this moment. Up to 30 days in the future per Resend's
+        cap. We convert to ISO 8601 with timezone before handing off;
+        a naive datetime is treated as UTC. Past values are passed
+        through unchanged (Resend rejects them with 422; we surface
+        that error rather than silently sending immediately).
+
+      idempotency_key: scopes the API call. If you POST again with the
+        same key inside Resend's 24-hour window, you'll get the same
+        message id back instead of a duplicate send. Use a stable
+        identifier per logical operation — e.g. for reminders,
+        `reminder.t-24h:appt-{id}`. Validator: 1–256 chars.
+
+    Callers should treat a `None` return as "delivery not attempted"
+    — for critical flows (password reset) decide explicitly whether
+    that should bubble up as a user-visible error.
+    """
+    if not is_configured():
+        raise unprocessable("email_not_configured")
+
+    recipients = [to] if isinstance(to, str) else list(to)
+    sendable, suppressed = _filter_suppressed(db, recipients)
+    if suppressed:
+        _logger.info(
+            "resend.send skipped %d suppressed recipient(s): %s",
+            len(suppressed), suppressed,
+        )
+    if not sendable:
+        return None
+
+    resend.api_key = settings.RESEND_API_KEY
+    params: dict = {
+        "from": settings.RESEND_FROM,
+        "to": sendable,
+        "subject": subject,
+        "html": html,
+    }
+    if text:
+        params["text"] = text
+    if settings.RESEND_REPLY_TO:
+        params["reply_to"] = settings.RESEND_REPLY_TO
+    if scheduled_at is not None:
+        # Resend accepts ISO 8601 with timezone. A naive datetime is
+        # treated as UTC — explicit assumption documented in the
+        # docstring so call sites don't get a silent timezone shift.
+        from datetime import timezone as _tz
+        when = scheduled_at if scheduled_at.tzinfo else scheduled_at.replace(tzinfo=_tz.utc)
+        params["scheduled_at"] = when.isoformat()
+    if tags:
+        # Resend expects [{"name": ..., "value": ...}, …]; tags surface
+        # in their dashboard and webhook payloads for filtering. Their
+        # validator rejects anything outside [A-Za-z0-9_-], so we
+        # normalise on the way out — internal `kind` strings like
+        # "reminder.t-24h" become "reminder_t-24h" without callers
+        # needing to think about it.
+        params["tags"] = [
+            {"name": _sanitize_tag(k), "value": _sanitize_tag(v)}
+            for k, v in tags.items()
+        ]
+
+    options = None
+    if idempotency_key:
+        # SendOptions is just a TypedDict; the SDK forwards `idempotency_key`
+        # as the `Idempotency-Key` HTTP header. Resend dedups same-key calls
+        # within a 24h window.
+        options = {"idempotency_key": idempotency_key}
+
+    result = resend.Emails.send(params, options) if options else resend.Emails.send(params)
+    msg_id = result.get("id") if isinstance(result, dict) else None
+    _logger.info(
+        "resend.sent id=%s to=%s subject=%r scheduled_at=%s key=%s",
+        msg_id, sendable, subject,
+        params.get("scheduled_at"), idempotency_key,
+    )
+    return msg_id
+
+
+def update_scheduled(*, msg_id: str, scheduled_at: "datetime") -> None:
+    """Reschedule an unsent email at Resend.
+
+    Only `scheduled_at` is updatable — Resend doesn't let you change
+    subject, body, or recipients. If the message has already been sent
+    we get a 4xx; callers should wrap in try/except and treat that as
+    "too late to change, oh well" since the email did go out.
+    """
+    if not is_configured():
+        raise unprocessable("email_not_configured")
+    from datetime import timezone as _tz
+    when = scheduled_at if scheduled_at.tzinfo else scheduled_at.replace(tzinfo=_tz.utc)
+    resend.api_key = settings.RESEND_API_KEY
+    resend.Emails.update({"id": msg_id, "scheduled_at": when.isoformat()})
+    _logger.info("resend.updated id=%s new_scheduled_at=%s", msg_id, when.isoformat())
+
+
+def cancel_scheduled(*, msg_id: str) -> None:
+    """Cancel an unsent scheduled email at Resend.
+
+    Permanent — Resend won't let you un-cancel. Same already-sent error
+    handling applies: cancel-after-send is best-effort.
+    """
+    if not is_configured():
+        raise unprocessable("email_not_configured")
+    resend.api_key = settings.RESEND_API_KEY
+    resend.Emails.cancel(msg_id)
+    _logger.info("resend.cancelled id=%s", msg_id)
+
+
+def suppress(
+    db: Session, *, email: str, reason: str, detail: dict | None = None,
+) -> None:
+    """Idempotently mark an address as do-not-send.
+
+    Called from the webhook handler on bounce/complaint. Safe to call
+    repeatedly: the row's primary key is the lowercased email, and we
+    overwrite reason+detail with the latest event so an operator sees
+    the most recent cause when investigating.
+    """
+    addr = _normalize(email)
+    if not addr:
+        return
+    existing = db.get(EmailSuppression, addr)
+    if existing is None:
+        db.add(
+            EmailSuppression(email=addr, reason=reason, detail=detail or {})
+        )
+    else:
+        existing.reason = reason
+        existing.detail = detail or {}
+    db.commit()
+    _logger.info("email suppression upserted: %s reason=%s", addr, reason)
+
+
+def render(template_stem: str, **context) -> tuple[str, str]:
+    """Render a template pair into (html, text).
+
+    `template_stem` is the filename without extension — e.g. "doctor_invite"
+    looks up "doctor_invite.html" and "doctor_invite.txt". Both must exist;
+    we always send a text alternative because spam filters score lower on
+    HTML-only mail and screen readers prefer the text part.
+
+    The caller's context dict is merged with a few globals (institute_name,
+    reply_to) pulled from system_config so every template can rely on them
+    without each call site repeating itself. System config lookup is done
+    lazily inside the function because tests can render templates without
+    a live LiveConfig cache.
+    """
+    full_context = {**_global_context(), **context}
+    try:
+        html_tmpl = _jinja.get_template(f"{template_stem}.html")
+        text_tmpl = _jinja.get_template(f"{template_stem}.txt")
+    except Exception as exc:
+        # A missing template is a deploy bug, not a runtime user error —
+        # surface it as 500-class via unhandled exception rather than a
+        # silent fallback string.
+        raise RuntimeError(f"email template {template_stem!r} not found: {exc}")
+    return html_tmpl.render(**full_context), text_tmpl.render(**full_context)
+
+
+def _global_context() -> dict:
+    """Variables every template can reference without an explicit pass."""
+    # Lazy import to avoid a hard dependency on system_config being loaded
+    # at module-import time (tests, alembic env.py).
+    try:
+        from .system_config import get_system_config
+        cfg = get_system_config()
+        institute_name = cfg.institute_name
+    except Exception:
+        institute_name = None
+    return {
+        "institute_name": institute_name or "HapuTele",
+        "reply_to": settings.RESEND_REPLY_TO or None,
+    }
+
+
+def send_templated(
+    db: Session,
+    *,
+    to: str | list[str],
+    subject: str,
+    template: str,
+    context: dict,
+    tags: dict[str, str] | None = None,
+    scheduled_at: "datetime | None" = None,
+    idempotency_key: str | None = None,
+) -> str | None:
+    """Render `template` with `context` and send via send_email().
+
+    Convenience wrapper for the common case of "fill in a Jinja template
+    and ship it". `scheduled_at` and `idempotency_key` pass through
+    unchanged — see send_email() for semantics.
+    """
+    html, text = render(template, **context)
+    return send_email(
+        db,
+        to=to,
+        subject=subject,
+        html=html,
+        text=text,
+        tags=tags,
+        scheduled_at=scheduled_at,
+        idempotency_key=idempotency_key,
+    )

--- a/backend/app/templates/email/appointment_reminder.html
+++ b/backend/app/templates/email/appointment_reminder.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+{% block heading %}
+  {% if window == "t-24h" %}Reminder: consultation tomorrow{% else %}Reminder: consultation in 1 hour{% endif %}
+{% endblock %}
+{% block body %}
+  <p>Hi Dr. {{ doctor_family_name }},</p>
+  <p>
+    {% if window == "t-24h" %}
+      You have a consultation scheduled for tomorrow.
+    {% else %}
+      You have a consultation starting in about an hour.
+    {% endif %}
+  </p>
+  <table cellpadding="0" cellspacing="0" border="0"
+         style="margin:16px 0;background:#f9fafb;border:1px solid #e5e7eb;border-radius:6px;padding:16px;width:100%;">
+    <tr>
+      <td style="font-size:14px;color:#6b7280;padding-right:16px;">Patient</td>
+      <td style="font-size:15px;color:#111827;font-weight:600;">{{ patient_given_name }} {{ patient_family_name }}</td>
+    </tr>
+    <tr>
+      <td style="font-size:14px;color:#6b7280;padding-right:16px;padding-top:8px;">When</td>
+      <td style="font-size:15px;color:#111827;padding-top:8px;">{{ scheduled_at_local }}</td>
+    </tr>
+    <tr>
+      <td style="font-size:14px;color:#6b7280;padding-right:16px;padding-top:8px;">Appointment ID</td>
+      <td style="font-size:15px;color:#111827;padding-top:8px;">#{{ appointment_id }}</td>
+    </tr>
+  </table>
+{% endblock %}

--- a/backend/app/templates/email/appointment_reminder.txt
+++ b/backend/app/templates/email/appointment_reminder.txt
@@ -1,0 +1,14 @@
+Hi Dr. {{ doctor_family_name }},
+
+{% if window == "t-24h" -%}
+You have a consultation scheduled for tomorrow.
+{%- else -%}
+You have a consultation starting in about an hour.
+{%- endif %}
+
+  Patient:        {{ patient_given_name }} {{ patient_family_name }}
+  When:           {{ scheduled_at_local }}
+  Appointment ID: #{{ appointment_id }}
+
+--
+{{ institute_name | default("HapuTele") }}

--- a/backend/app/templates/email/base.html
+++ b/backend/app/templates/email/base.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block heading %}{% endblock %}</title>
+</head>
+<body style="margin:0;padding:0;background:#f5f5f7;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;color:#1f2937;">
+  <table width="100%" cellpadding="0" cellspacing="0" border="0" style="padding:24px 0;">
+    <tr>
+      <td align="center">
+        <table width="560" cellpadding="0" cellspacing="0" border="0"
+               style="max-width:560px;width:100%;background:#ffffff;border-radius:8px;padding:32px;box-shadow:0 1px 3px rgba(0,0,0,0.06);">
+          <tr>
+            <td>
+              <div style="font-size:14px;color:#6b7280;letter-spacing:0.04em;text-transform:uppercase;margin-bottom:8px;">
+                {{ institute_name | default("HapuTele") }}
+              </div>
+              <h1 style="font-size:22px;line-height:1.3;margin:0 0 16px 0;color:#111827;">
+                {% block heading_h1 %}{{ self.heading() }}{% endblock %}
+              </h1>
+              <div style="font-size:15px;line-height:1.55;color:#1f2937;">
+                {% block body %}{% endblock %}
+              </div>
+              {% block cta %}{% endblock %}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding-top:32px;border-top:1px solid #e5e7eb;margin-top:32px;">
+              <p style="font-size:12px;color:#9ca3af;margin:24px 0 0 0;line-height:1.5;">
+                This is an automated message from {{ institute_name | default("HapuTele") }}.
+                {% if reply_to %}Reply to <a href="mailto:{{ reply_to }}" style="color:#6b7280;">{{ reply_to }}</a> if you have questions.{% endif %}
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/backend/app/templates/email/doctor_approved.html
+++ b/backend/app/templates/email/doctor_approved.html
@@ -1,0 +1,22 @@
+{% extends "base.html" %}
+{% block heading %}Your account is approved{% endblock %}
+{% block body %}
+  <p>Hi Dr. {{ family_name }},</p>
+  <p>
+    Your account at {{ institute_name | default("HapuTele") }} has been approved
+    by an administrator. You can now sign in using the username and password
+    you chose during onboarding.
+  </p>
+{% endblock %}
+{% block cta %}
+  <div style="margin-top:24px;">
+    <a href="{{ login_link }}"
+       style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:6px;font-weight:600;font-size:15px;">
+      Sign in
+    </a>
+  </div>
+  <p style="font-size:12px;color:#9ca3af;margin-top:24px;word-break:break-all;">
+    Or paste this URL into your browser:<br>
+    <span style="color:#6b7280;">{{ login_link }}</span>
+  </p>
+{% endblock %}

--- a/backend/app/templates/email/doctor_approved.txt
+++ b/backend/app/templates/email/doctor_approved.txt
@@ -1,0 +1,10 @@
+Hi Dr. {{ family_name }},
+
+Your account at {{ institute_name | default("HapuTele") }} has been approved by
+an administrator. You can now sign in using the username and password you
+chose during onboarding.
+
+    {{ login_link }}
+
+--
+{{ institute_name | default("HapuTele") }}

--- a/backend/app/templates/email/doctor_invite.html
+++ b/backend/app/templates/email/doctor_invite.html
@@ -1,0 +1,59 @@
+{% extends "base.html" %}
+{% block heading %}
+  {% if mode == "new" %}You're invited to {{ institute_name | default("HapuTele") }}{% else %}Set your password{% endif %}
+{% endblock %}
+{% block body %}
+  {# Greeting. For new-doctor invites we don't know they hold a doctorate
+     until they tell us, so we drop the "Dr." prefix. If the admin
+     provided a family-name hint, we use it as a plain first-line name. #}
+  {# We're inviting them to a practitioner programme, so treat them as
+     a doctor in both modes. With a family-name hint we use it; without
+     one we fall back to the role title. #}
+  {% if family_name %}
+    <p>Hi Dr. {{ family_name }},</p>
+  {% else %}
+    <p>Hi Doctor,</p>
+  {% endif %}
+
+  {% if mode == "new" %}
+    <p>
+      An administrator at {{ institute_name | default("HapuTele") }} has invited
+      you to join the practitioner programme. Click the link below to provide
+      your information — name, contact, SLMC registration, qualifications, your
+      institute, and your prescription rubber stamp.
+    </p>
+    <p>
+      Once you submit, an administrator will review the information you
+      provided. We&rsquo;ll notify you by email as soon as your account is
+      approved and ready to use.
+    </p>
+  {% else %}
+    <p>
+      An account has been created for you at {{ institute_name | default("HapuTele") }}.
+      Set your password using the link below to finish onboarding.
+    </p>
+  {% endif %}
+
+  <p style="color:#6b7280;font-size:13px;">
+    This link expires in {{ expires_hours }} hours.
+    {% if mode == "new" %}
+      If you didn&rsquo;t expect this invitation, you can safely ignore it —
+      no account is created until you complete the form.
+    {% else %}
+      If you didn&rsquo;t expect this email, you can ignore it — the account
+      stays inert until the link is used.
+    {% endif %}
+  </p>
+{% endblock %}
+{% block cta %}
+  <div style="margin-top:24px;">
+    <a href="{{ link }}"
+       style="display:inline-block;background:#111827;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:6px;font-weight:600;font-size:15px;">
+      {% if mode == "new" %}Provide your information{% else %}Set your password{% endif %}
+    </a>
+  </div>
+  <p style="font-size:12px;color:#9ca3af;margin-top:24px;word-break:break-all;">
+    Or paste this URL into your browser:<br>
+    <span style="color:#6b7280;">{{ link }}</span>
+  </p>
+{% endblock %}

--- a/backend/app/templates/email/doctor_invite.txt
+++ b/backend/app/templates/email/doctor_invite.txt
@@ -1,0 +1,35 @@
+{% if family_name -%}
+Hi Dr. {{ family_name }},
+{%- else -%}
+Hi Doctor,
+{%- endif %}
+
+{% if mode == "new" -%}
+An administrator at {{ institute_name | default("HapuTele") }} has invited you
+to join the practitioner programme.
+
+Click the link below to provide your information — name, contact, SLMC
+registration, qualifications, your institute, and your prescription rubber
+stamp:
+
+    {{ link }}
+
+Once you submit, an administrator will review the information you provided.
+We'll notify you by email as soon as your account is approved and ready to use.
+
+This link expires in {{ expires_hours }} hours. If you didn't expect this
+invitation, you can safely ignore it — no account is created until you
+complete the form.
+{%- else -%}
+An account has been created for you at {{ institute_name | default("HapuTele") }}.
+
+Set your password using the link below to finish onboarding:
+
+    {{ link }}
+
+This link expires in {{ expires_hours }} hours. If you didn't expect this
+email, you can ignore it — the account stays inert until the link is used.
+{%- endif %}
+
+--
+{{ institute_name | default("HapuTele") }}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -14,3 +14,6 @@ reportlab==4.2.5
 openpyxl==3.1.5
 livekit-api==1.1.0
 boto3==1.35.84
+resend==2.30.1
+svix==1.45.1
+jinja2==3.1.4

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -117,15 +117,26 @@ def _wipe_setup_state():
     db = SessionLocal()
     try:
         # Wipe accounts (cascades to doctor / availability via FK).
+        # The `appointments_locked_guard` trigger from migration 0005 has a
+        # bug: as a BEFORE-DELETE trigger it returns NEW (which is NULL for
+        # DELETE), silently suppressing the delete. We disable it for the
+        # duration of the wipe. (See bug note in the feature-end summary.)
         db.execute(text("DELETE FROM appointment_attachments"))
         db.execute(text("DELETE FROM consultations"))
         db.execute(text("DELETE FROM preconsultation"))
         db.execute(text("DELETE FROM consents"))
+        db.execute(text("ALTER TABLE appointments DISABLE TRIGGER appointments_locked_guard"))
         db.execute(text("DELETE FROM appointments"))
+        db.execute(text("ALTER TABLE appointments ENABLE TRIGGER appointments_locked_guard"))
         db.execute(text("DELETE FROM queue_entries"))
         db.execute(text("DELETE FROM doctor_availability"))
         db.execute(text("DELETE FROM profile"))
         db.execute(text("DELETE FROM patients"))
+        # Resend-feature tables — wiped explicitly even though they cascade
+        # from doctor / are FK-less, so test order is irrelevant.
+        db.execute(text("DELETE FROM notification_log"))
+        db.execute(text("DELETE FROM doctor_invites"))
+        db.execute(text("DELETE FROM email_suppressions"))
         db.execute(text("DELETE FROM doctor"))
         db.execute(text("DELETE FROM accounts"))
         db.execute(text("DELETE FROM setup_tokens"))
@@ -161,6 +172,192 @@ def client():
     from fastapi.testclient import TestClient
     with TestClient(app_main.app) as c:
         yield c
+
+
+# ── Fixtures for the Resend / doctor-invite / reminder tests ────────────
+
+@pytest.fixture
+def email_env(monkeypatch):
+    """Force the email service into 'configured' mode for tests.
+
+    Without this, `is_configured()` is False and any code path that
+    sends mail short-circuits with 422 — which is the *opposite* of
+    what we want to verify in the happy-path tests. The api key value
+    is fake; nothing actually hits Resend because `captured_emails`
+    monkeypatches the send functions.
+    """
+    monkeypatch.setenv("RESEND_API_KEY", "re_test_fake_key_for_unit_tests")
+    monkeypatch.setenv("RESEND_FROM", "test@example.com")
+    monkeypatch.setenv("FRONTEND_BASE_URL", "http://testserver")
+    # The Settings object was already constructed at module import; mutate
+    # it in-place so downstream `settings.X` reads pick up the new values.
+    from app.config import settings as _settings
+    monkeypatch.setattr(_settings, "RESEND_API_KEY", "re_test_fake_key_for_unit_tests")
+    monkeypatch.setattr(_settings, "RESEND_FROM", "test@example.com")
+    monkeypatch.setattr(_settings, "FRONTEND_BASE_URL", "http://testserver")
+
+
+@pytest.fixture
+def captured_emails(monkeypatch):
+    """Intercept outbound email at the seam every caller uses.
+
+    Returns a list of `(fn_name, kwargs)` tuples — one per call. Each
+    monkeypatch points at the *binding inside the calling module*
+    (router / script / service), because Python imports copy references
+    at import time; replacing `app.services.email.send_templated` alone
+    wouldn't be seen by routers that have already done
+    `from ..services.email import send_templated`.
+    """
+    calls: list[tuple[str, dict]] = []
+    counter = {"n": 0}
+
+    def _fake_send_templated(db, **kwargs):
+        counter["n"] += 1
+        calls.append(("send_templated", kwargs))
+        return f"fake-msg-id-{counter['n']}"
+
+    def _fake_send_email(db, **kwargs):
+        counter["n"] += 1
+        calls.append(("send_email", kwargs))
+        return f"fake-msg-id-{counter['n']}"
+
+    # Patch at every import site we know about.
+    monkeypatch.setattr("app.services.email.send_templated", _fake_send_templated)
+    monkeypatch.setattr("app.services.email.send_email", _fake_send_email)
+    monkeypatch.setattr("app.routers.doctors.send_templated", _fake_send_templated)
+    return calls
+
+
+def _initialize_system_directly(db) -> None:
+    """Flip system_config to initialized without going through the wizard,
+    then refresh the in-memory cache.
+
+    Faster than the verify-token → initialize flow for tests that only
+    care about post-init behaviour (doctor onboarding, reminders). The
+    cache refresh is critical: the setup-gate middleware reads from a
+    module-level cache, not the DB, so an in-place DB UPDATE isn't
+    visible without explicitly re-loading.
+    """
+    from sqlalchemy import text
+    from app.services.system_config import load_system_config
+    db.execute(text(
+        "UPDATE system_config SET "
+        "  initialized_at = NOW(), "
+        "  institute_name = 'Test Clinic', "
+        "  institute_address_lines = '[\"Test St\"]'::jsonb, "
+        "  institute_contact_phone = '+94 11 000 0000', "
+        "  institute_contact_email = 'ops@example.com', "
+        "  app_timezone = 'Asia/Colombo', "
+        "  export_timezone = 'Asia/Colombo', "
+        "  master_consent_version = 'v1' "
+        "WHERE id = 1"
+    ))
+    db.commit()
+    load_system_config(db)
+
+
+@pytest.fixture
+def initialized_system():
+    """system_config flipped to 'initialized' so post-setup routes work."""
+    from app.database import SessionLocal
+    db = SessionLocal()
+    try:
+        _initialize_system_directly(db)
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def admin_account(initialized_system):
+    """Seed an admin Account row. Returns (username, plaintext_password)."""
+    from app.database import SessionLocal
+    from app.models import Account
+    from app.security import hash_password
+
+    creds = ("test_admin", "TestAdmin-Password-123")
+    db = SessionLocal()
+    try:
+        db.add(Account(username=creds[0], password=hash_password(creds[1]), role="admin"))
+        db.commit()
+    finally:
+        db.close()
+    return creds
+
+
+@pytest.fixture
+def admin_client(client, admin_account):
+    """TestClient already logged in as the admin (cookies pre-set)."""
+    username, password = admin_account
+    r = client.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return client
+
+
+@pytest.fixture
+def healthworker_account(initialized_system):
+    """Seed a healthworker Account. Returns (username, password)."""
+    from app.database import SessionLocal
+    from app.models import Account
+    from app.security import hash_password
+
+    creds = ("test_hw", "TestHW-Password-123")
+    db = SessionLocal()
+    try:
+        db.add(Account(username=creds[0], password=hash_password(creds[1]), role="healthworker"))
+        db.commit()
+    finally:
+        db.close()
+    return creds
+
+
+@pytest.fixture
+def seeded_doctor(initialized_system):
+    """A Doctor + Account ready to be invited. Returns the Doctor row.
+
+    The Account row's password is a random unguessable value (same as
+    what create_doctor's invite mode would generate), so tests that
+    verify "consume updates the password" can assert on a known-after
+    state without knowing the before-state.
+    """
+    import secrets
+    from datetime import datetime, timezone
+
+    from app.database import SessionLocal
+    from app.models import Account, Doctor
+    from app.security import hash_password
+
+    db = SessionLocal()
+    try:
+        username = "dr_test_seeded"
+        db.add(Account(
+            username=username,
+            password=hash_password(secrets.token_urlsafe(32)),
+            role="doctor",
+        ))
+        db.add(Doctor(
+            username=username,
+            given_name="Test", family_name="Doctor",
+            contact="+94 11 000 0000",
+            email="dr_test@example.com",
+            slmc_registration_number="SLMC-TEST",
+            qualifications="MBBS",
+            practitioner_address="Test Address",
+            institute_name="Test Clinic",
+            institute_contact="+94 11 111 1111",
+            rubber_stamp_image=b"\x89PNG\r\n\x1a\n",
+            active=True,
+            # Represents a pre-existing (already approved) doctor — the
+            # invite-by-email flow has a separate path for fresh ones.
+            approved_at=datetime.now(timezone.utc),
+        ))
+        db.commit()
+        doctor = db.query(Doctor).filter_by(username=username).first()
+        # Detach from session so the fixture-consumer can use it after this
+        # fixture's session closes.
+        db.expunge(doctor)
+        return doctor
+    finally:
+        db.close()
 
 
 @pytest.fixture

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -344,7 +344,10 @@ def seeded_doctor(initialized_system):
             practitioner_address="Test Address",
             institute_name="Test Clinic",
             institute_contact="+94 11 111 1111",
-            rubber_stamp_image=b"\x89PNG\r\n\x1a\n",
+            # Post-S3 migration: column is rubber_stamp_key. We don't put
+            # actual bytes anywhere — no test reads the stamp back — so a
+            # fake key is fine.
+            rubber_stamp_key="test/stub-stamp-key.png",
             active=True,
             # Represents a pre-existing (already approved) doctor — the
             # invite-by-email flow has a separate path for fresh ones.

--- a/backend/tests/test_doctor_invite_by_email.py
+++ b/backend/tests/test_doctor_invite_by_email.py
@@ -1,0 +1,312 @@
+"""Tests for the invite-by-email + admin-approval flow.
+
+Covers:
+  - Admin issues an email-only invite, no Doctor row yet.
+  - Doctor visits the link — peek returns mode=new + email.
+  - Doctor submits the full profile — Account + Doctor row appear,
+    onboardingStatus = awaiting_approval, doctor can't log in yet.
+  - Admin approves — login works.
+  - Admin rejects — login refused with `account_rejected`.
+  - Double-invite same email → 409 email_already_used.
+  - Healthworker doctor list filters out awaiting_approval doctors.
+"""
+from __future__ import annotations
+
+import base64
+
+from app.database import SessionLocal
+from app.models import Doctor
+
+
+_PNG_1x1 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+).decode("ascii")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+def _submission(**overrides) -> dict:
+    base = {
+        "username": "drnewbie",
+        "password": "MyNewSecure-Password-123",
+        "givenName": "Asha",
+        "familyName": "Silva",
+        "contact": "+94 11 555 0100",
+        # No email — the invite owns the email value; the server uses
+        # invite.email regardless of what the client sends.
+        "slmcRegistrationNumber": "SLMC-9999",
+        "qualifications": "MBBS",
+        "practitionerAddress": "1 Test St",
+        "instituteName": "Test Clinic",
+        "instituteContact": "+94 11 555 0101",
+        "rubberStampImage": _PNG_1x1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _invite_via_admin(admin_client, *, email: str, family_name: str | None = None) -> str:
+    """Issue an invite via POST /doctors/invites and return the raw token
+    by inspecting the DB (the token doesn't come back in the response)."""
+    body: dict = {"email": email}
+    if family_name:
+        body["familyName"] = family_name
+    r = admin_client.post("/doctors/invites", json=body, headers=_csrf(admin_client))
+    assert r.status_code == 201, r.text
+
+    # Pull the raw token by reissuing through the service (idempotency-key
+    # path is simpler than parsing the email). The new invite revokes the
+    # one we just issued — fine for testing.
+    from app.services import doctor_invites
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue_new_doctor(db, email=email, family_name=family_name)
+    finally:
+        db.close()
+    return raw
+
+
+def test_invite_creates_no_doctor_row(admin_client, email_env, captured_emails):
+    r = admin_client.post(
+        "/doctors/invites",
+        json={"email": "fresh@example.com"},
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["email"] == "fresh@example.com"
+    assert "inviteId" in body
+
+    # Doctor row count unchanged (only the seeded doctor exists, if any)
+    db = SessionLocal()
+    try:
+        assert db.query(Doctor).filter_by(email="fresh@example.com").count() == 0
+    finally:
+        db.close()
+
+    # An invite email was sent.
+    sends = [c for c in captured_emails if c[0] == "send_templated"]
+    assert len(sends) == 1
+    assert sends[0][1]["template"] == "doctor_invite"
+
+
+def test_double_invite_same_email_is_rejected(
+    admin_client, email_env, captured_emails,
+):
+    r1 = admin_client.post(
+        "/doctors/invites", json={"email": "twin@example.com"},
+        headers=_csrf(admin_client),
+    )
+    assert r1.status_code == 201
+    r2 = admin_client.post(
+        "/doctors/invites", json={"email": "twin@example.com"},
+        headers=_csrf(admin_client),
+    )
+    # Second call lands on the "live invite exists" branch — we revoke the
+    # old one and issue a fresh one, so it succeeds. (Operators sometimes
+    # click resend twice; rejecting would be hostile.)
+    assert r2.status_code == 201
+
+
+def test_invite_to_existing_email_returns_email_already_used(
+    admin_client, email_env, captured_emails, seeded_doctor,
+):
+    """seeded_doctor's email already belongs to a real doctor row."""
+    r = admin_client.post(
+        "/doctors/invites", json={"email": seeded_doctor.email},
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 409, r.text
+    assert r.json()["detail"]["error"] == "email_already_used"
+
+
+def test_peek_on_new_invite_returns_mode_new(
+    admin_client, email_env, captured_emails, client,
+):
+    raw = _invite_via_admin(admin_client, email="peek@example.com", family_name="Perera")
+    r = client.get(f"/doctor-onboarding/{raw}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["mode"] == "new"
+    assert body["email"] == "peek@example.com"
+    assert body["familyName"] == "Perera"
+    assert body.get("givenName") is None
+
+
+def test_full_self_onboarding_flow(
+    admin_client, email_env, captured_emails, client,
+):
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    r = client.post(
+        f"/doctor-onboarding/{raw}",
+        json=_submission(),
+    )
+    assert r.status_code == 204, r.text
+
+    # Account + Doctor exist, doctor is awaiting_approval.
+    r = admin_client.get("/doctors")
+    by_username = {d["username"]: d for d in r.json()}
+    assert "drnewbie" in by_username
+    assert by_username["drnewbie"]["onboardingStatus"] == "awaiting_approval"
+
+    # Doctor can't log in yet.
+    r = client.post("/auth/login", json={"username": "drnewbie", "password": "MyNewSecure-Password-123"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["error"] == "account_pending_approval"
+
+
+def test_admin_approval_unlocks_login_and_sends_notification(
+    admin_client, email_env, captured_emails, client,
+):
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    client.post(f"/doctor-onboarding/{raw}", json=_submission())
+
+    captured_emails.clear()  # ignore the invite send
+
+    # Find the doctor id, approve.
+    r = admin_client.get("/doctors")
+    doctor_id = next(d["id"] for d in r.json() if d["username"] == "drnewbie")
+    r = admin_client.post(
+        f"/doctors/{doctor_id}/approve", headers=_csrf(admin_client),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["onboardingStatus"] == "active"
+
+    # The "your account is approved" email fired exactly once, to the
+    # invite's email address, with the right template.
+    sends = [c for c in captured_emails if c[0] == "send_templated"]
+    assert len(sends) == 1
+    _, kwargs = sends[0]
+    assert kwargs["template"] == "doctor_approved"
+    assert kwargs["to"] == "asha.silva@example.com"
+    assert kwargs["idempotency_key"] == f"doctor.approved:doctor-{doctor_id}"
+    assert kwargs["context"]["family_name"] == "Silva"
+    assert "/login" in kwargs["context"]["login_link"]
+
+    # Login now works.
+    r = client.post(
+        "/auth/login",
+        json={"username": "drnewbie", "password": "MyNewSecure-Password-123"},
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_double_approve_does_not_resend_notification(
+    admin_client, email_env, captured_emails, client,
+):
+    """An accidental double-click on Approve shouldn't email the doctor
+    twice. The endpoint short-circuits on the NULL→ts transition and
+    the email is only sent inside that transition."""
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    client.post(f"/doctor-onboarding/{raw}", json=_submission())
+    captured_emails.clear()
+    r = admin_client.get("/doctors")
+    doctor_id = next(d["id"] for d in r.json() if d["username"] == "drnewbie")
+
+    admin_client.post(f"/doctors/{doctor_id}/approve", headers=_csrf(admin_client))
+    admin_client.post(f"/doctors/{doctor_id}/approve", headers=_csrf(admin_client))
+
+    sends = [c for c in captured_emails if c[0] == "send_templated"]
+    assert len(sends) == 1
+
+
+def test_admin_reject_blocks_login_with_reason(
+    admin_client, email_env, captured_emails, client,
+):
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    client.post(f"/doctor-onboarding/{raw}", json=_submission())
+
+    r = admin_client.get("/doctors")
+    doctor_id = next(d["id"] for d in r.json() if d["username"] == "drnewbie")
+    r = admin_client.post(
+        f"/doctors/{doctor_id}/reject",
+        json={"reason": "SLMC number is invalid"},
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["onboardingStatus"] == "rejected"
+    assert body["active"] is False
+
+    # Login refused with account_rejected.
+    r = client.post(
+        "/auth/login",
+        json={"username": "drnewbie", "password": "MyNewSecure-Password-123"},
+    )
+    assert r.status_code == 403
+    assert r.json()["detail"]["error"] == "account_rejected"
+
+
+def test_approve_after_reject_is_blocked(
+    admin_client, email_env, captured_emails, client,
+):
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    client.post(f"/doctor-onboarding/{raw}", json=_submission())
+    r = admin_client.get("/doctors")
+    doctor_id = next(d["id"] for d in r.json() if d["username"] == "drnewbie")
+
+    admin_client.post(
+        f"/doctors/{doctor_id}/reject", json={"reason": "x"},
+        headers=_csrf(admin_client),
+    )
+    r = admin_client.post(
+        f"/doctors/{doctor_id}/approve", headers=_csrf(admin_client),
+    )
+    assert r.status_code == 409
+    assert r.json()["detail"]["error"] == "doctor_rejected"
+
+
+def test_healthworker_list_filters_out_awaiting_approval(
+    admin_client, email_env, captured_emails, healthworker_account,
+):
+    """admin_client and healthworker_client share the same TestClient
+    cookie jar, so taking both as fixtures would have the second login
+    silently overwrite the first. We do the admin work first while
+    admin_client is logged in, then log out + log in as healthworker on
+    the same client to verify the booking-side filter.
+    """
+    raw = _invite_via_admin(admin_client, email="asha.silva@example.com")
+    admin_client.post(
+        f"/doctor-onboarding/{raw}", json=_submission(),
+        # No CSRF needed — doctor-onboarding is public.
+    )
+
+    # Admin sees the awaiting-approval doctor.
+    r = admin_client.get("/doctors")
+    assert "drnewbie" in {d["username"] for d in r.json()}
+
+    # Switch roles: log out + log in as healthworker on the same client.
+    admin_client.post("/auth/logout", headers=_csrf(admin_client))
+    hw_user, hw_pw = healthworker_account
+    r = admin_client.post("/auth/login", json={"username": hw_user, "password": hw_pw})
+    assert r.status_code == 200, r.text
+
+    r = admin_client.get("/doctors")
+    hw_usernames = {d["username"] for d in r.json()}
+    assert "drnewbie" not in hw_usernames
+
+
+def test_doctor_account_email_always_uses_invite_email(
+    admin_client, email_env, captured_emails, client,
+):
+    """The submission can't include an email — the schema rejects it — but
+    even if a client tries to slip one in, the server uses invite.email
+    when creating the Doctor row."""
+    raw = _invite_via_admin(admin_client, email="invited@example.com")
+    # Try to sneak a different email through. extra="ignore" semantics on
+    # the schema mean pydantic just drops the unknown field; the resulting
+    # Doctor row still gets invited@example.com.
+    body = _submission()
+    body["email"] = "different@example.com"  # ignored by server
+    r = client.post(f"/doctor-onboarding/{raw}", json=body)
+    assert r.status_code == 204, r.text
+
+    r = admin_client.get("/doctors")
+    drnewbie = next(d for d in r.json() if d["username"] == "drnewbie")
+    assert drnewbie["email"] == "invited@example.com"

--- a/backend/tests/test_doctor_invites_service.py
+++ b/backend/tests/test_doctor_invites_service.py
@@ -1,0 +1,147 @@
+"""Tests for app/services/doctor_invites.py — the token lifecycle.
+
+Covers:
+  - issue() mints a row, hashes the token, sets expires_at.
+  - issue() called twice revokes the prior live invite.
+  - lookup_live() returns the row only for tokens that are live.
+  - consume() updates the doctor's account password.
+  - consume() rejects already-consumed / expired tokens with 404
+    `invite_not_found`.
+  - build_invite_link() refuses when FRONTEND_BASE_URL is empty.
+"""
+from __future__ import annotations
+
+import hashlib
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.database import SessionLocal
+from app.models import Account, DoctorInvite
+from app.security import verify_password
+from app.services import doctor_invites as invites
+
+
+def test_issue_mints_row_with_hashed_token(seeded_doctor):
+    db = SessionLocal()
+    try:
+        row, raw = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        # The raw token never leaves this function past the return — the DB
+        # only stores the sha256 hex.
+        assert row.token_hash == hashlib.sha256(raw.encode()).hexdigest()
+        assert row.token_hash != raw
+        assert len(row.token_hash) == 64
+        # Expires in the future, within DOCTOR_INVITE_TTL_HOURS tolerance.
+        now = datetime.now(timezone.utc)
+        assert row.expires_at > now
+        assert row.expires_at < now + timedelta(hours=200)
+        assert row.consumed_at is None
+    finally:
+        db.close()
+
+
+def test_issue_revokes_prior_live_invite(seeded_doctor):
+    db = SessionLocal()
+    try:
+        _, raw1 = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        _, raw2 = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        # The old token can no longer be looked up.
+        with pytest.raises(Exception) as exc:
+            invites.lookup_live(db, raw_token=raw1)
+        assert "invite_not_found" in str(exc.value.detail)
+        # The new token still works.
+        row = invites.lookup_live(db, raw_token=raw2)
+        assert row.doctor_id == seeded_doctor.doctor_id
+    finally:
+        db.close()
+
+
+def test_issue_raises_when_doctor_missing():
+    db = SessionLocal()
+    try:
+        with pytest.raises(Exception) as exc:
+            invites.issue(db, doctor_id=9999)
+        assert "doctor_not_found" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+def test_lookup_live_rejects_unknown_token(initialized_system):
+    db = SessionLocal()
+    try:
+        with pytest.raises(Exception) as exc:
+            invites.lookup_live(db, raw_token="totally-fake-token")
+        assert "invite_not_found" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+def test_lookup_live_rejects_expired(seeded_doctor):
+    """Manually backdate an invite past its expires_at."""
+    db = SessionLocal()
+    try:
+        row, raw = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        row.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
+        db.commit()
+        with pytest.raises(Exception) as exc:
+            invites.lookup_live(db, raw_token=raw)
+        assert "invite_not_found" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+def test_consume_sets_password_and_marks_consumed(seeded_doctor):
+    db = SessionLocal()
+    try:
+        _, raw = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        new_pw = "the-new-password-12345"
+        doctor = invites.consume(db, raw_token=raw, new_password=new_pw)
+        assert doctor.doctor_id == seeded_doctor.doctor_id
+
+        # Account password was updated and verifies.
+        account = db.get(Account, seeded_doctor.username)
+        assert verify_password(new_pw, account.password)
+
+        # Invite row is marked consumed.
+        row = db.query(DoctorInvite).filter_by(doctor_id=doctor.doctor_id).first()
+        assert row.consumed_at is not None
+    finally:
+        db.close()
+
+
+def test_consume_rejects_second_use(seeded_doctor):
+    db = SessionLocal()
+    try:
+        _, raw = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        invites.consume(db, raw_token=raw, new_password="first-password-12345")
+        with pytest.raises(Exception) as exc:
+            invites.consume(db, raw_token=raw, new_password="second-password-12345")
+        assert "invite_not_found" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+def test_consume_rejects_empty_password(seeded_doctor):
+    db = SessionLocal()
+    try:
+        _, raw = invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+        with pytest.raises(Exception) as exc:
+            invites.consume(db, raw_token=raw, new_password="")
+        assert "missing_password" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+def test_build_invite_link_requires_frontend_base_url(monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings, "FRONTEND_BASE_URL", "")
+    with pytest.raises(Exception) as exc:
+        invites.build_invite_link("some-token")
+    assert "frontend_base_url_not_configured" in str(exc.value.detail)
+
+
+def test_build_invite_link_constructs_expected_url(monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings, "FRONTEND_BASE_URL", "https://app.test")
+    url = invites.build_invite_link("abc-123_xyz")
+    assert url == "https://app.test/doctor-onboarding/abc-123_xyz"

--- a/backend/tests/test_doctor_onboarding_api.py
+++ b/backend/tests/test_doctor_onboarding_api.py
@@ -1,0 +1,273 @@
+"""API-level tests for the doctor-onboarding flow.
+
+Two surfaces to verify:
+
+  (1) Admin side — POST /doctors with no password fires an invite;
+      POST /doctors/{id}/invites re-fires.
+  (2) Doctor side — GET /doctor-onboarding/{token} returns peek info;
+      POST /doctor-onboarding/{token} sets the password.
+
+`captured_emails` intercepts outbound mail so we can assert on the
+template + context the routers chose, without hitting Resend.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from app.database import SessionLocal
+from app.models import Account, Doctor, DoctorInvite
+
+
+# Minimal valid PNG (1×1 px) for the rubber-stamp field.
+_PNG_1x1 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+).decode("ascii")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token, "csrf_token cookie missing — not logged in?"
+    return {"X-CSRF-Token": token}
+
+
+def _doctor_payload(**overrides) -> dict:
+    base = {
+        "username": "dr_invite_test",
+        "givenName": "Asha",
+        "familyName": "Silva",
+        "contact": "+94 11 555 0100",
+        "email": "asha.silva@example.com",
+        "slmcRegistrationNumber": "SLMC-123",
+        "qualifications": "MBBS",
+        "practitionerAddress": "1 Test St",
+        "instituteName": "Test Clinic",
+        "instituteContact": "+94 11 555 0101",
+        "rubberStampImage": _PNG_1x1,
+    }
+    base.update(overrides)
+    return base
+
+
+# ── Admin: create_doctor invite-mode happy path ────────────────────
+
+def test_create_doctor_without_password_fires_invite_email(
+    admin_client, email_env, captured_emails,
+):
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201, r.text
+
+    # Exactly one templated email — the invite.
+    invite_calls = [c for c in captured_emails if c[0] == "send_templated"]
+    assert len(invite_calls) == 1
+    _, kwargs = invite_calls[0]
+    assert kwargs["template"] == "doctor_invite"
+    assert kwargs["to"] == "asha.silva@example.com"
+    assert "link" in kwargs["context"]
+    assert kwargs["context"]["family_name"] == "Silva"
+
+    # A live invite row exists for the new doctor.
+    db = SessionLocal()
+    try:
+        doctor = db.query(Doctor).filter_by(username="dr_invite_test").one()
+        invite_rows = db.query(DoctorInvite).filter_by(doctor_id=doctor.doctor_id).all()
+        assert len(invite_rows) == 1
+        assert invite_rows[0].consumed_at is None
+    finally:
+        db.close()
+
+
+def test_create_doctor_with_password_does_not_fire_invite(
+    admin_client, email_env, captured_emails,
+):
+    r = admin_client.post(
+        "/doctors",
+        json=_doctor_payload(password="manual-password-set"),
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201, r.text
+    # No invite email; no invite row.
+    invite_calls = [c for c in captured_emails if c[0] == "send_templated"]
+    assert invite_calls == []
+    db = SessionLocal()
+    try:
+        doctor = db.query(Doctor).filter_by(username="dr_invite_test").one()
+        n = db.query(DoctorInvite).filter_by(doctor_id=doctor.doctor_id).count()
+        assert n == 0
+    finally:
+        db.close()
+
+
+def test_create_doctor_without_password_requires_email_configured(
+    admin_client, monkeypatch,
+):
+    """If RESEND_API_KEY is empty we can't invite — refuse the create
+    rather than land a broken account.
+    """
+    from app.config import settings
+    monkeypatch.setattr(settings, "RESEND_API_KEY", "")
+    monkeypatch.setattr(settings, "RESEND_FROM", "")
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["error"] == "email_not_configured"
+
+
+# ── Admin: reissue_invite endpoint ─────────────────────────────────
+
+def test_reissue_invite_revokes_prior(
+    admin_client, email_env, captured_emails,
+):
+    # Create with invite → first invite sent.
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201
+
+    db = SessionLocal()
+    try:
+        doctor = db.query(Doctor).filter_by(username="dr_invite_test").one()
+        doctor_id = doctor.doctor_id
+    finally:
+        db.close()
+
+    # Re-issue.
+    r = admin_client.post(
+        f"/doctors/{doctor_id}/invites", headers=_csrf(admin_client),
+    )
+    assert r.status_code == 204
+
+    # Two templated calls now; only the latest invite row is unconsumed.
+    invite_calls = [c for c in captured_emails if c[0] == "send_templated"]
+    assert len(invite_calls) == 2
+    db = SessionLocal()
+    try:
+        rows = (
+            db.query(DoctorInvite)
+            .filter_by(doctor_id=doctor_id)
+            .order_by(DoctorInvite.created_at)
+            .all()
+        )
+        assert len(rows) == 2
+        assert rows[0].consumed_at is not None  # superseded
+        assert rows[1].consumed_at is None      # current
+    finally:
+        db.close()
+
+
+def test_reissue_invite_404_for_unknown_doctor(admin_client, email_env):
+    r = admin_client.post("/doctors/9999/invites", headers=_csrf(admin_client))
+    assert r.status_code == 404
+
+
+# ── Doctor: onboarding GET + POST ──────────────────────────────────
+
+def test_onboarding_peek_returns_name(client, seeded_doctor):
+    from app.services import doctor_invites
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+    finally:
+        db.close()
+
+    r = client.get(f"/doctor-onboarding/{raw}")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    # Rotation invite — returns mode + email + both names.
+    assert body["mode"] == "rotation"
+    assert body["givenName"] == "Test"
+    assert body["familyName"] == "Doctor"
+    assert body["email"] == "dr_test@example.com"
+
+
+def test_onboarding_peek_404_for_unknown_token(client, initialized_system):
+    r = client.get("/doctor-onboarding/totally-fake-token")
+    assert r.status_code == 404
+    assert r.json()["detail"]["error"] == "invite_not_found"
+
+
+def test_onboarding_complete_sets_password(client, seeded_doctor):
+    from app.services import doctor_invites
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+    finally:
+        db.close()
+
+    r = client.post(
+        f"/doctor-onboarding/{raw}",
+        json={"password": "the-doctors-chosen-password-12345"},
+    )
+    assert r.status_code == 204, r.text
+
+    # The doctor can now log in with the new password.
+    r = client.post(
+        "/auth/login",
+        json={
+            "username": "dr_test_seeded",
+            "password": "the-doctors-chosen-password-12345",
+        },
+    )
+    assert r.status_code == 200, r.text
+
+
+def test_onboarding_complete_rejects_short_password(client, seeded_doctor):
+    from app.services import doctor_invites
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+    finally:
+        db.close()
+
+    r = client.post(f"/doctor-onboarding/{raw}", json={"password": "short"})
+    assert r.status_code == 422
+    body = r.json()["detail"]
+    assert body["error"] == "password_too_short"
+    assert body.get("minLength") == 8
+
+
+def test_onboarding_complete_is_single_use(client, seeded_doctor):
+    from app.services import doctor_invites
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue(db, doctor_id=seeded_doctor.doctor_id)
+    finally:
+        db.close()
+
+    r1 = client.post(
+        f"/doctor-onboarding/{raw}",
+        json={"password": "first-attempt-password-12345"},
+    )
+    assert r1.status_code == 204
+
+    r2 = client.post(
+        f"/doctor-onboarding/{raw}",
+        json={"password": "second-attempt-should-fail-12345"},
+    )
+    assert r2.status_code == 404
+    assert r2.json()["detail"]["error"] == "invite_not_found"
+
+
+# ── Doctor: onboarding routes are public (no session needed) ───────
+
+def test_onboarding_does_not_require_session(client, seeded_doctor):
+    """The doctor isn't logged in yet — these endpoints accept anonymous
+    requests guarded only by the token. Verify no `current_user`
+    dependency is wired in by checking 404 vs 401 on a stale token.
+    """
+    # Stale → 404, not 401. (401 would mean an auth dep ran first.)
+    r = client.get("/doctor-onboarding/stale-token")
+    assert r.status_code == 404
+
+
+def test_onboarding_blocked_pre_init(client):
+    """Before /setup/initialize, the gate 409s anything non-setup."""
+    r = client.get("/doctor-onboarding/any-token")
+    assert r.status_code == 409
+    assert r.json()["detail"]["error"] == "setup_required"

--- a/backend/tests/test_doctor_onboarding_status.py
+++ b/backend/tests/test_doctor_onboarding_status.py
@@ -1,0 +1,186 @@
+"""Tests for the `onboardingStatus` field on DoctorOut.
+
+  - List endpoint returns "awaiting_setup" for a doctor with a live
+    invite, "active" otherwise.
+  - Detail endpoint mirrors the list endpoint.
+  - Consuming the invite flips status → "active".
+  - Re-issue brings it back to "awaiting_setup".
+  - Manual-password create-doctor returns "active" immediately.
+"""
+from __future__ import annotations
+
+import base64
+
+from app.database import SessionLocal
+from app.services import doctor_invites
+
+
+# 1×1 PNG, used to satisfy the rubber-stamp field on create.
+_PNG_1x1 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+).decode("ascii")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+def _doctor_payload(**overrides) -> dict:
+    base = {
+        "username": "dr_status_test",
+        "givenName": "Asha",
+        "familyName": "Silva",
+        "contact": "+94 11 555 0100",
+        "email": "asha.silva@example.com",
+        "slmcRegistrationNumber": "SLMC-1",
+        "qualifications": "MBBS",
+        "practitionerAddress": "1 Test St",
+        "instituteName": "Test Clinic",
+        "instituteContact": "+94 11 555 0101",
+        "rubberStampImage": _PNG_1x1,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_create_with_invite_returns_awaiting_setup(
+    admin_client, email_env, captured_emails,
+):
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["onboardingStatus"] == "awaiting_setup"
+
+
+def test_create_with_manual_password_returns_active(
+    admin_client, email_env, captured_emails,
+):
+    r = admin_client.post(
+        "/doctors",
+        json=_doctor_payload(password="manually-set-password"),
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["onboardingStatus"] == "active"
+
+
+def test_list_endpoint_reports_status_per_doctor(
+    admin_client, email_env, captured_emails,
+):
+    # Doctor 1 — invite mode
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(username="dr_a", email="a@example.com"),
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201
+
+    # Doctor 2 — manual mode
+    r = admin_client.post(
+        "/doctors",
+        json=_doctor_payload(
+            username="dr_b", email="b@example.com", password="manual-pw",
+        ),
+        headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201
+
+    r = admin_client.get("/doctors")
+    assert r.status_code == 200
+    by_username = {d["username"]: d for d in r.json()}
+    assert by_username["dr_a"]["onboardingStatus"] == "awaiting_setup"
+    assert by_username["dr_b"]["onboardingStatus"] == "active"
+
+
+def test_consuming_invite_flips_status_to_active(
+    admin_client, email_env, captured_emails, client,
+):
+    # Create with invite
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    assert r.status_code == 201
+    doctor_id = r.json()["id"]
+
+    # Grab the raw token via the service (the test bypasses the email-delivery
+    # side, but the issue() result is what the email would carry).
+    db = SessionLocal()
+    try:
+        invite, raw = doctor_invites.issue(db, doctor_id=doctor_id)
+    finally:
+        db.close()
+
+    # Consume via the public onboarding endpoint
+    r = client.post(
+        f"/doctor-onboarding/{raw}",
+        json={"password": "doctor-chosen-password-12345"},
+    )
+    assert r.status_code == 204, r.text
+
+    # GET /doctors/{id} now reports active
+    r = admin_client.get(f"/doctors/{doctor_id}")
+    assert r.status_code == 200
+    assert r.json()["onboardingStatus"] == "active"
+
+
+def test_reissue_invite_brings_status_back_to_awaiting_setup(
+    admin_client, email_env, captured_emails, client,
+):
+    # Create + onboard
+    r = admin_client.post(
+        "/doctors", json=_doctor_payload(), headers=_csrf(admin_client),
+    )
+    doctor_id = r.json()["id"]
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue(db, doctor_id=doctor_id)
+    finally:
+        db.close()
+    client.post(
+        f"/doctor-onboarding/{raw}",
+        json={"password": "first-password-12345"},
+    )
+
+    # Admin re-issues
+    r = admin_client.post(
+        f"/doctors/{doctor_id}/invites", headers=_csrf(admin_client),
+    )
+    assert r.status_code == 204
+
+    # Detail endpoint now shows awaiting_setup again
+    r = admin_client.get(f"/doctors/{doctor_id}")
+    assert r.status_code == 200
+    assert r.json()["onboardingStatus"] == "awaiting_setup"
+
+
+def test_status_uses_single_query_for_list(
+    admin_client, email_env, captured_emails,
+):
+    """Sanity check that the helper produces correct results for N>1
+    doctors without each one querying separately. We can't easily count
+    DB queries from the test without instrumenting SQLAlchemy events, so
+    instead we assert that all four states are reported correctly in one
+    list call — exercising the batched IN-clause path."""
+    # Three doctors: two awaiting, one active.
+    for i, (username, password) in enumerate([
+        ("dr_w1", None), ("dr_w2", None), ("dr_w3", "manual-pw"),
+    ]):
+        body = _doctor_payload(
+            username=username, email=f"{username}@example.com",
+        )
+        if password:
+            body["password"] = password
+        r = admin_client.post("/doctors", json=body, headers=_csrf(admin_client))
+        assert r.status_code == 201, r.text
+
+    r = admin_client.get("/doctors")
+    assert r.status_code == 200
+    by_username = {d["username"]: d for d in r.json()}
+    assert by_username["dr_w1"]["onboardingStatus"] == "awaiting_setup"
+    assert by_username["dr_w2"]["onboardingStatus"] == "awaiting_setup"
+    assert by_username["dr_w3"]["onboardingStatus"] == "active"

--- a/backend/tests/test_email_service.py
+++ b/backend/tests/test_email_service.py
@@ -1,0 +1,283 @@
+"""Tests for app/services/email.py.
+
+These tests don't hit the live Resend API — `captured_emails` swaps the
+send functions for in-memory recorders. The point is to verify that the
+service's own logic (suppression filtering, tag sanitisation, template
+render contract) does what the docstrings claim.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.database import SessionLocal
+from app.models import EmailSuppression
+from app.services import email as email_svc
+
+
+# ── Configuration state ────────────────────────────────────────────
+
+def test_is_configured_false_when_api_key_missing(monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings, "RESEND_API_KEY", "")
+    monkeypatch.setattr(settings, "RESEND_FROM", "from@example.com")
+    assert email_svc.is_configured() is False
+
+
+def test_is_configured_false_when_from_missing(monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings, "RESEND_API_KEY", "re_x")
+    monkeypatch.setattr(settings, "RESEND_FROM", "")
+    assert email_svc.is_configured() is False
+
+
+def test_is_configured_true_when_both_set(email_env):
+    assert email_svc.is_configured() is True
+
+
+def test_send_email_raises_when_not_configured(monkeypatch):
+    from app.config import settings
+    monkeypatch.setattr(settings, "RESEND_API_KEY", "")
+    db = SessionLocal()
+    try:
+        with pytest.raises(Exception) as exc:
+            email_svc.send_email(db, to="x@example.com", subject="s", html="<p>h</p>")
+        # HTTPException with our standard error envelope.
+        assert "email_not_configured" in str(exc.value.detail)
+    finally:
+        db.close()
+
+
+# ── Suppression filter ─────────────────────────────────────────────
+
+def test_filter_suppressed_partitions_correctly():
+    db = SessionLocal()
+    try:
+        db.add(EmailSuppression(email="bouncy@example.com", reason="bounced.hard"))
+        db.commit()
+        sendable, suppressed = email_svc._filter_suppressed(
+            db, ["bouncy@example.com", "Fresh@example.com", " AlsoFresh@Example.com "]
+        )
+        # Both lists are lowercased + trimmed for primary-key match.
+        assert "fresh@example.com" in sendable
+        assert "alsofresh@example.com" in sendable
+        assert "bouncy@example.com" not in sendable
+        assert suppressed == ["bouncy@example.com"]
+    finally:
+        db.close()
+
+
+def test_filter_suppressed_empty_input():
+    db = SessionLocal()
+    try:
+        assert email_svc._filter_suppressed(db, []) == ([], [])
+        assert email_svc._filter_suppressed(db, ["", None]) == ([], [])  # type: ignore[list-item]
+    finally:
+        db.close()
+
+
+def test_suppress_is_idempotent():
+    """Calling suppress() twice for the same address upserts in place."""
+    db = SessionLocal()
+    try:
+        email_svc.suppress(db, email="DUPE@example.com", reason="bounced.hard")
+        email_svc.suppress(db, email="dupe@example.com", reason="complained")
+        row = db.get(EmailSuppression, "dupe@example.com")
+        assert row is not None
+        # The second call's reason wins.
+        assert row.reason == "complained"
+        # And there's exactly one row.
+        n = db.query(EmailSuppression).filter_by(email="dupe@example.com").count()
+        assert n == 1
+    finally:
+        db.close()
+
+
+# ── Tag sanitisation ────────────────────────────────────────────────
+
+def test_tag_sanitizer_strips_disallowed_chars():
+    # Internal kind values use dots; Resend forbids them. The sanitizer
+    # must produce strictly [A-Za-z0-9_-]. Dots, spaces, colons → "_".
+    assert email_svc._sanitize_tag("reminder.t-24h") == "reminder_t-24h"
+    assert email_svc._sanitize_tag("doctor.invite") == "doctor_invite"
+    assert email_svc._sanitize_tag("foo bar:baz/qux") == "foo_bar_baz_qux"
+    assert email_svc._sanitize_tag("already_safe-1") == "already_safe-1"
+    assert email_svc._sanitize_tag("123") == "123"
+
+
+# ── Template rendering ──────────────────────────────────────────────
+
+def test_render_doctor_invite_rotation_mode():
+    html, text = email_svc.render(
+        "doctor_invite",
+        mode="rotation",
+        family_name="Perera",
+        link="https://x.test/d/abc",
+        expires_hours=72,
+    )
+    # Rotation copy must include the password language and the family name
+    # in the greeting; new-doctor language must not.
+    assert "Perera" in html and "Perera" in text
+    assert "Set your password" in html
+    assert "An account has been created" in text
+    assert "provide your information" not in text.lower()
+    assert "72" in text
+
+
+def test_render_doctor_invite_new_mode_no_family_name():
+    html, text = email_svc.render(
+        "doctor_invite",
+        mode="new",
+        family_name=None,
+        link="https://x.test/d/abc",
+        expires_hours=72,
+    )
+    # No-name fallback addresses them by role — "Hi Doctor," — since the
+    # whole point of the invite is they're joining the practitioner
+    # programme. New-doctor copy talks about providing information and
+    # admin approval rather than setting a password.
+    assert "Hi Doctor," in text
+    assert "Hi there" not in text
+    assert "provide your information" in text.lower()
+    assert "review" in text.lower() or "approved" in text.lower()
+    assert "Set your password" not in text
+
+
+def test_render_doctor_invite_new_mode_with_family_name():
+    html, text = email_svc.render(
+        "doctor_invite",
+        mode="new",
+        family_name="Perera",
+        link="https://x.test/d/abc",
+        expires_hours=72,
+    )
+    # With a name hint, both modes greet "Hi Dr. {family_name}," —
+    # consistent and respectful.
+    assert "Hi Dr. Perera," in text
+
+
+def test_render_appointment_reminder_branches_on_window():
+    html_24, text_24 = email_svc.render(
+        "appointment_reminder",
+        doctor_family_name="Perera",
+        patient_given_name="Asha", patient_family_name="Silva",
+        scheduled_at_local="2026-05-29 14:30 (Asia/Colombo)",
+        appointment_id=42, window="t-24h",
+    )
+    html_1, text_1 = email_svc.render(
+        "appointment_reminder",
+        doctor_family_name="Perera",
+        patient_given_name="Asha", patient_family_name="Silva",
+        scheduled_at_local="2026-05-28 15:30 (Asia/Colombo)",
+        appointment_id=42, window="t-1h",
+    )
+    assert "tomorrow" in text_24
+    assert "tomorrow" not in text_1
+    assert "in about an hour" in text_1
+
+
+def test_render_unknown_template_raises():
+    with pytest.raises(RuntimeError) as exc:
+        email_svc.render("does_not_exist", x=1)
+    assert "does_not_exist" in str(exc.value)
+
+
+def test_render_undefined_variable_raises():
+    """StrictUndefined turns typos into immediate exceptions instead of
+    silently rendering blanks — important for catching template bugs in
+    CI rather than after the email has gone out.
+    """
+    with pytest.raises(Exception):
+        # appointment_reminder requires window, scheduled_at_local, etc.
+        email_svc.render("appointment_reminder", doctor_family_name="P")
+
+
+# ── send_email integration with captured_emails ────────────────────
+
+def test_send_email_passes_scheduled_at_and_idempotency_to_sdk(
+    email_env, monkeypatch,
+):
+    """Verify the real send_email() (un-mocked) forwards scheduled_at +
+    idempotency_key to the Resend SDK call as ISO 8601 + SendOptions."""
+    from datetime import datetime, timezone
+    captured: dict = {}
+
+    def _fake_send(params, options=None):
+        captured["params"] = params
+        captured["options"] = options
+        return {"id": "fake-id"}
+
+    monkeypatch.setattr("resend.Emails.send", _fake_send)
+
+    import importlib
+    import app.services.email as real
+    importlib.reload(real)
+
+    from app.database import SessionLocal
+    db = SessionLocal()
+    try:
+        when = datetime(2026, 6, 1, 14, 0, tzinfo=timezone.utc)
+        real.send_email(
+            db, to="x@example.com", subject="s", html="<p>h</p>",
+            scheduled_at=when, idempotency_key="reminder.t-24h:appt-42",
+        )
+    finally:
+        db.close()
+
+    assert captured["params"]["scheduled_at"] == "2026-06-01T14:00:00+00:00"
+    assert captured["options"] == {"idempotency_key": "reminder.t-24h:appt-42"}
+
+
+def test_send_email_naive_datetime_treated_as_utc(email_env, monkeypatch):
+    """A naive datetime gets a UTC tzinfo before being serialised — no
+    silent timezone shift."""
+    from datetime import datetime
+    captured: dict = {}
+
+    def _fake_send(params, options=None):
+        captured["params"] = params
+        return {"id": "fake-id"}
+
+    monkeypatch.setattr("resend.Emails.send", _fake_send)
+
+    import importlib
+    import app.services.email as real
+    importlib.reload(real)
+
+    from app.database import SessionLocal
+    db = SessionLocal()
+    try:
+        real.send_email(
+            db, to="x@example.com", subject="s", html="<p>h</p>",
+            scheduled_at=datetime(2026, 6, 1, 14, 0),  # naive
+        )
+    finally:
+        db.close()
+
+    assert captured["params"]["scheduled_at"] == "2026-06-01T14:00:00+00:00"
+
+
+def test_send_email_skips_suppressed_recipients(email_env, captured_emails):
+    """When every recipient is on the suppression list, no Resend call
+    happens — verified by `captured_emails` staying empty for the real
+    Resend SDK path. (Our mock replaces send_email itself, so we test
+    the real one via _filter_suppressed; this test is a sanity check
+    that the function returns None.)
+    """
+    from app.database import SessionLocal
+    db = SessionLocal()
+    try:
+        db.add(EmailSuppression(email="all@suppressed.test", reason="bounced.hard"))
+        db.commit()
+        # Use the real send_email (un-mocked), bypassing captured_emails:
+        # the mock replaced services.email.send_email but we want to test
+        # the real implementation. We reach in via the underlying module.
+        import importlib
+        import app.services.email as real
+        importlib.reload(real)
+        result = real.send_email(
+            db, to="all@suppressed.test", subject="s", html="<p>h</p>",
+        )
+        # No recipients left → returns None without hitting Resend.
+        assert result is None
+    finally:
+        db.close()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,6 +94,12 @@ services:
       S3_ACCESS_KEY_ID: ${S3_ACCESS_KEY_ID:-rustfsadmin}
       S3_SECRET_ACCESS_KEY: ${S3_SECRET_ACCESS_KEY:-rustfsadmin}
       S3_FORCE_PATH_STYLE: ${S3_FORCE_PATH_STYLE:-true}
+      RESEND_API_KEY: ${RESEND_API_KEY:-}
+      RESEND_FROM: ${RESEND_FROM:-}
+      RESEND_REPLY_TO: ${RESEND_REPLY_TO:-}
+      RESEND_WEBHOOK_SECRET: ${RESEND_WEBHOOK_SECRET:-}
+      FRONTEND_BASE_URL: ${FRONTEND_BASE_URL:-}
+      DOCTOR_INVITE_TTL_HOURS: ${DOCTOR_INVITE_TTL_HOURS:-72}
     volumes:
       # Persists the plaintext setup-token file across container restarts.
       # `docker compose down -v` clears it (same volume lifecycle as db_data).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1201,13 +1201,6 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@types/dom-mediacapture-record": {
-      "version": "1.0.22",
-      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
-      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/json5": {
       "version": "0.0.29",
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",

--- a/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
+++ b/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
@@ -3,18 +3,22 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useState } from "react";
-import { ArrowLeft, ToggleLeft, ToggleRight } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Mail, RefreshCw, ShieldCheck, ShieldX, ToggleLeft, ToggleRight, XCircle } from "lucide-react";
 
 import { DoctorForm } from "@/components/admin/doctor-form";
 import { Button } from "@/components/primitives/button";
 import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
+import { Input, Label } from "@/components/primitives/input";
 import { Modal } from "@/components/primitives/modal";
 import { PageHeader } from "@/components/primitives/page-header";
 import { StatusBadge } from "@/components/primitives/status-badge";
 import {
+  useApproveDoctor,
   useDeactivateDoctor,
   useDoctor,
+  useReissueDoctorInvite,
+  useRejectDoctor,
   useUpdateDoctor,
 } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
@@ -28,7 +32,16 @@ export default function DoctorDetailPage() {
   const doctor = useDoctor(Number.isFinite(id) ? id : null);
   const update = useUpdateDoctor(id);
   const deactivate = useDeactivateDoctor();
+  const reissueInvite = useReissueDoctorInvite();
+  const approve = useApproveDoctor();
+  const reject = useRejectDoctor();
   const [confirmOpen, setConfirmOpen] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+  const [rejectReason, setRejectReason] = useState("");
+  // Lightweight one-shot ack after re-sending. Cleared when the user
+  // navigates away (component unmount). No toast system in scope here,
+  // so we render a small inline pill.
+  const [inviteJustSent, setInviteJustSent] = useState(false);
 
   if (doctor.error) {
     return (
@@ -91,6 +104,126 @@ export default function DoctorDetailPage() {
         }
       />
 
+      {/* Awaiting-approval banner — the doctor has submitted their
+          profile, you need to review and click Approve (or Reject). */}
+      {d.onboardingStatus === "awaiting_approval" && (
+        <Card className="border-sky-200 bg-sky-50/50 p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="rounded-lg bg-sky-100 p-2">
+                <ShieldCheck className="h-4 w-4 text-sky-700" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-sky-900">
+                  Awaiting your approval
+                </p>
+                <p className="mt-1 text-sm text-sky-800">
+                  This doctor submitted their profile. Review the §1.7 fields
+                  below, then approve to let them log in.
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <Button
+                variant="ghost"
+                size="md"
+                onClick={() => setRejectOpen(true)}
+                disabled={approve.isPending || reject.isPending}
+              >
+                <ShieldX className="h-4 w-4" />
+                Reject
+              </Button>
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={() => approve.mutate(d.id)}
+                disabled={approve.isPending}
+              >
+                <CheckCircle2 className={`h-4 w-4 ${approve.isPending ? "animate-pulse" : ""}`} />
+                {approve.isPending ? "Approving…" : "Approve"}
+              </Button>
+            </div>
+          </div>
+          {approve.error && (
+            <ErrorBanner className="mt-3">{explainError(approve.error.error)}</ErrorBanner>
+          )}
+        </Card>
+      )}
+
+      {/* Rejected banner — terminal state. */}
+      {d.onboardingStatus === "rejected" && (
+        <Card className="border-rose-200 bg-rose-50/50 p-5">
+          <div className="flex items-start gap-3">
+            <div className="rounded-lg bg-rose-100 p-2">
+              <XCircle className="h-4 w-4 text-rose-700" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-rose-900">
+                Submission rejected
+              </p>
+              <p className="mt-1 text-sm text-rose-800">
+                The doctor can&rsquo;t log in. Re-issue an invite if you want
+                them to try again.
+              </p>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {/* Awaiting-setup banner. Only renders when there's a live unconsumed
+          invite for this doctor; folds in the re-send affordance so the
+          admin doesn't have to dig for it. */}
+      {d.onboardingStatus === "awaiting_setup" && (
+        <Card className="border-amber-200 bg-amber-50/50 p-5">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+            <div className="flex items-start gap-3">
+              <div className="rounded-lg bg-amber-100 p-2">
+                <Mail className="h-4 w-4 text-amber-700" />
+              </div>
+              <div>
+                <p className="text-sm font-semibold text-amber-900">
+                  Awaiting onboarding
+                </p>
+                <p className="mt-1 text-sm text-amber-800">
+                  This doctor hasn&rsquo;t set their password yet. The most
+                  recent invite link is still active.
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              {inviteJustSent && (
+                <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-700">
+                  <CheckCircle2 className="h-3 w-3" />
+                  Sent
+                </span>
+              )}
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={() =>
+                  reissueInvite.mutate(d.id, {
+                    onSuccess: () => {
+                      setInviteJustSent(true);
+                      // Hide the "Sent" pill after 4s so it doesn't sit there forever.
+                      setTimeout(() => setInviteJustSent(false), 4000);
+                    },
+                  })
+                }
+                disabled={reissueInvite.isPending}
+              >
+                <RefreshCw className={`h-4 w-4 ${reissueInvite.isPending ? "animate-spin" : ""}`} />
+                {reissueInvite.isPending ? "Sending…" : "Re-send invite"}
+              </Button>
+            </div>
+          </div>
+          {reissueInvite.error && (
+            <ErrorBanner className="mt-3">
+              {explainError(reissueInvite.error.error)}
+            </ErrorBanner>
+          )}
+        </Card>
+      )}
+
       <Card variant="elevated" className="p-8">
         <DoctorForm
           mode="update"
@@ -119,6 +252,52 @@ export default function DoctorDetailPage() {
           onCancel={() => router.push("/admin")}
         />
       </Card>
+
+      <Modal
+        open={rejectOpen}
+        onClose={() => !reject.isPending && setRejectOpen(false)}
+        title="Reject this submission?"
+        description="The doctor won't be able to log in. They'll see the reason you enter below if they try."
+      >
+        {reject.error && (
+          <ErrorBanner className="mb-3">{explainError(reject.error.error)}</ErrorBanner>
+        )}
+        <div className="mb-4 flex flex-col gap-2">
+          <Label htmlFor="reject-reason">Reason (shown to the doctor)</Label>
+          <Input
+            id="reject-reason"
+            value={rejectReason}
+            onChange={(e) => setRejectReason(e.target.value)}
+            placeholder="e.g. SLMC number couldn't be verified"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => setRejectOpen(false)}
+            disabled={reject.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={() =>
+              reject.mutate(
+                { id: d.id, reason: rejectReason.trim() || undefined },
+                {
+                  onSuccess: () => {
+                    setRejectOpen(false);
+                    setRejectReason("");
+                  },
+                },
+              )
+            }
+            disabled={reject.isPending}
+          >
+            {reject.isPending ? "Rejecting…" : "Reject submission"}
+          </Button>
+        </div>
+      </Modal>
 
       <Modal
         open={confirmOpen}

--- a/frontend/src/app/(app)/admin/doctors/new/page.tsx
+++ b/frontend/src/app/(app)/admin/doctors/new/page.tsx
@@ -1,29 +1,31 @@
 "use client";
 
-import { useRouter } from "next/navigation";
+import { useState, type FormEvent } from "react";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { useRouter } from "next/navigation";
+import { ArrowLeft, ArrowRight, IdCard, Mail } from "lucide-react";
 
 import { DoctorForm } from "@/components/admin/doctor-form";
+import { Button } from "@/components/primitives/button";
 import { Card } from "@/components/primitives/card";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { Input, Label } from "@/components/primitives/input";
 import { PageHeader } from "@/components/primitives/page-header";
-import { useCreateDoctor } from "@/lib/use-api";
+import { useCreateDoctor, useInviteDoctor } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
+
+// Two ways to add a doctor:
+//   "invite"  → admin types only email (+ optional name hint). Doctor
+//               fills the rest via the public onboarding link, then waits
+//               for admin approval. This is the recommended path.
+//   "manual"  → admin types everything (legacy). Useful when the doctor
+//               can't be reached by email or when bulk-importing from
+//               another system.
+type Mode = "invite" | "manual";
 
 export default function NewDoctorPage() {
   const router = useRouter();
-  const create = useCreateDoctor();
-
-  // Backend returns either `username_taken`, `missing_prescription_fields`
-  // (with a `missing` array), or `invalid_rubber_stamp_image`. We surface
-  // each clearly.
-  const errCode = create.error?.error ?? null;
-  const missing = (create.error?.detail?.missing as string[] | undefined) ?? undefined;
-  const errorMessage = errCode
-    ? errCode === "missing_prescription_fields"
-      ? "Some §1.7 mandatory fields couldn't be validated server-side."
-      : explainError(errCode)
-    : null;
+  const [mode, setMode] = useState<Mode>("invite");
 
   return (
     <div className="mx-auto flex max-w-4xl flex-col gap-10 px-6 py-12">
@@ -37,42 +39,221 @@ export default function NewDoctorPage() {
 
       <PageHeader
         label="New doctor"
-        title="Create a"
+        title="Add a"
         highlight="doctor account."
-        subtitle="Identity, login credentials, and the §1.7 prescription mandatory fields are all captured in one form. The rubber stamp image is required."
+        subtitle="Invite the doctor by email so they can fill out their own profile, or create the account manually if you've got all the §1.7 information already."
       />
 
-      <Card variant="elevated" className="p-8">
-        <DoctorForm
-          mode="create"
-          submitting={create.isPending}
-          errorMessage={errorMessage}
-          errorMissingFields={missing}
-          submitLabel="Create doctor"
-          onCancel={() => router.push("/admin")}
-          onSubmit={(payload) => {
-            // create requires username + password + rubberStampImage to be present;
-            // DoctorForm's create-mode validation guarantees this so we cast.
-            create.mutate(
-              {
-                username: payload.username!,
-                password: payload.password!,
-                givenName: payload.givenName,
-                familyName: payload.familyName,
-                contact: payload.contact,
-                email: payload.email,
-                slmcRegistrationNumber: payload.slmcRegistrationNumber,
-                qualifications: payload.qualifications,
-                practitionerAddress: payload.practitionerAddress,
-                instituteName: payload.instituteName,
-                instituteContact: payload.instituteContact,
-                rubberStampImage: payload.rubberStampImage!,
-              },
-              { onSuccess: (doc) => router.push(`/admin/doctors/${doc.id}`) },
-            );
-          }}
+      {/* Mode picker — full-width, sits above the form so the choice is obvious. */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <ModeCard
+          Icon={Mail}
+          title="Invite by email"
+          description="Type only the doctor's email. They fill out the full profile and you approve before they can log in."
+          recommended
+          selected={mode === "invite"}
+          onClick={() => setMode("invite")}
         />
+        <ModeCard
+          Icon={IdCard}
+          title="Create manually"
+          description="Type the full §1.7 profile yourself. Use this when the doctor isn't reachable by email or you're importing from another system."
+          selected={mode === "manual"}
+          onClick={() => setMode("manual")}
+        />
+      </div>
+
+      <Card variant="elevated" className="p-8">
+        {mode === "invite" ? (
+          <InvitePanel onDone={() => router.push("/admin")} />
+        ) : (
+          <ManualPanel onCancel={() => router.push("/admin")} onCreated={(id) => router.push(`/admin/doctors/${id}`)} />
+        )}
       </Card>
     </div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Invite panel — email + optional name hint, fires POST /doctors/invites
+ * ────────────────────────────────────────────────────────────────── */
+
+function InvitePanel({ onDone }: { onDone: () => void }) {
+  const invite = useInviteDoctor();
+  const [email, setEmail] = useState("");
+  const [familyName, setFamilyName] = useState("");
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    invite.mutate(
+      {
+        email: email.trim(),
+        familyName: familyName.trim() || undefined,
+      },
+      { onSuccess: onDone },
+    );
+  };
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col gap-6">
+      <div className="flex flex-col gap-1">
+        <h2 className="font-display text-2xl tracking-[-0.01em]">Invite a doctor by email</h2>
+        <p className="text-sm text-[var(--muted-foreground)]">
+          They&rsquo;ll receive a link to set up their account. Once they submit
+          their profile you&rsquo;ll be able to review and approve from the
+          doctor&rsquo;s page.
+        </p>
+      </div>
+
+      {invite.error && (
+        <ErrorBanner>{explainError(invite.error.error)}</ErrorBanner>
+      )}
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="invite-email">Doctor&rsquo;s email *</Label>
+        <Input
+          id="invite-email"
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="doctor@example.com"
+          required
+          autoFocus
+        />
+      </div>
+
+      <div className="flex flex-col gap-2">
+        <Label htmlFor="invite-family-name">Family name (optional)</Label>
+        <Input
+          id="invite-family-name"
+          value={familyName}
+          onChange={(e) => setFamilyName(e.target.value)}
+          placeholder="Perera"
+        />
+        <p className="text-xs text-[var(--muted-foreground)]">
+          Used only to personalise the invite email&rsquo;s greeting. The doctor
+          enters their full name themselves.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
+        <Button type="button" variant="secondary" onClick={onDone}>
+          Cancel
+        </Button>
+        <Button type="submit" disabled={invite.isPending || !email.trim()}>
+          {invite.isPending ? "Sending…" : "Send invite"}
+          <ArrowRight className="h-4 w-4" />
+        </Button>
+      </div>
+    </form>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Manual panel — the existing DoctorForm
+ * ────────────────────────────────────────────────────────────────── */
+
+function ManualPanel({
+  onCancel,
+  onCreated,
+}: {
+  onCancel: () => void;
+  onCreated: (id: number) => void;
+}) {
+  const create = useCreateDoctor();
+  const errCode = create.error?.error ?? null;
+  const missing = (create.error?.detail?.missing as string[] | undefined) ?? undefined;
+  const errorMessage = errCode
+    ? errCode === "missing_prescription_fields"
+      ? "Some §1.7 mandatory fields couldn't be validated server-side."
+      : explainError(errCode)
+    : null;
+
+  return (
+    <DoctorForm
+      mode="create"
+      submitting={create.isPending}
+      errorMessage={errorMessage}
+      errorMissingFields={missing}
+      submitLabel="Create doctor"
+      onCancel={onCancel}
+      onSubmit={(payload) => {
+        create.mutate(
+          {
+            username: payload.username!,
+            password: payload.password,
+            givenName: payload.givenName,
+            familyName: payload.familyName,
+            contact: payload.contact,
+            email: payload.email,
+            slmcRegistrationNumber: payload.slmcRegistrationNumber,
+            qualifications: payload.qualifications,
+            practitionerAddress: payload.practitionerAddress,
+            instituteName: payload.instituteName,
+            instituteContact: payload.instituteContact,
+            rubberStampImage: payload.rubberStampImage!,
+          },
+          { onSuccess: (doc) => onCreated(doc.id) },
+        );
+      }}
+    />
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * ModeCard — the same two-card chooser used inside DoctorForm
+ * ────────────────────────────────────────────────────────────────── */
+
+function ModeCard({
+  Icon,
+  title,
+  description,
+  recommended,
+  selected,
+  onClick,
+}: {
+  Icon: typeof Mail;
+  title: string;
+  description: string;
+  recommended?: boolean;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`flex items-start gap-3 rounded-2xl border p-5 text-left transition-all ${
+        selected
+          ? "border-[var(--accent)] bg-[var(--accent)]/5 shadow-sm"
+          : "border-[var(--border)] bg-transparent hover:border-[var(--accent)]/40"
+      }`}
+    >
+      <div
+        className={`rounded-lg p-2 ${
+          selected ? "bg-[var(--accent)]/15" : "bg-[var(--muted)]"
+        }`}
+      >
+        <Icon
+          className={`h-5 w-5 ${
+            selected ? "text-[var(--accent)]" : "text-[var(--muted-foreground)]"
+          }`}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="flex items-center gap-2 text-sm font-semibold">
+          {title}
+          {recommended && (
+            <span className="rounded-full bg-[var(--accent)]/10 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--accent)]">
+              Recommended
+            </span>
+          )}
+        </span>
+        <span className="text-xs leading-snug text-[var(--muted-foreground)]">
+          {description}
+        </span>
+      </div>
+    </button>
   );
 }

--- a/frontend/src/app/(app)/admin/page.tsx
+++ b/frontend/src/app/(app)/admin/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useState } from "react";
-import { CheckCircle2, Stethoscope, UserPlus2, XCircle } from "lucide-react";
+import { CheckCircle2, Mail, ShieldCheck, Stethoscope, UserPlus2, XCircle } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
 import { Card } from "@/components/primitives/card";
@@ -92,17 +92,42 @@ export default function AdminDoctors() {
                   <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-2 shadow-accent transition-transform duration-300 group-hover:scale-110">
                     <Stethoscope className="h-5 w-5 text-white" />
                   </div>
-                  {d.active ? (
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-700">
-                      <CheckCircle2 className="h-3 w-3" />
-                      Active
-                    </span>
-                  ) : (
-                    <span className="inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-rose-700">
-                      <XCircle className="h-3 w-3" />
-                      Inactive
-                    </span>
-                  )}
+                  {/* Two independent badges: active/inactive (account
+                      state) and awaiting-setup (invite outstanding). A
+                      deactivated doctor can also be awaiting setup if
+                      they were never onboarded — we show both badges
+                      stacked rather than collapsing one. */}
+                  <div className="flex flex-col items-end gap-1.5">
+                    {d.active ? (
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-700">
+                        <CheckCircle2 className="h-3 w-3" />
+                        Active
+                      </span>
+                    ) : (
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-rose-700">
+                        <XCircle className="h-3 w-3" />
+                        Inactive
+                      </span>
+                    )}
+                    {d.onboardingStatus === "awaiting_setup" && (
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-amber-700">
+                        <Mail className="h-3 w-3" />
+                        Awaiting setup
+                      </span>
+                    )}
+                    {d.onboardingStatus === "awaiting_approval" && (
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-sky-200 bg-sky-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-sky-700">
+                        <ShieldCheck className="h-3 w-3" />
+                        Awaiting approval
+                      </span>
+                    )}
+                    {d.onboardingStatus === "rejected" && (
+                      <span className="inline-flex items-center gap-1.5 rounded-full border border-rose-200 bg-rose-50 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-rose-700">
+                        <XCircle className="h-3 w-3" />
+                        Rejected
+                      </span>
+                    )}
+                  </div>
                 </div>
                 <h3 className="mt-4 font-display text-xl tracking-[-0.01em]">{doctorName(d)}</h3>
                 <p className="mt-1 text-sm text-[var(--muted-foreground)]">{d.email}</p>

--- a/frontend/src/app/doctor-onboarding/[token]/page.tsx
+++ b/frontend/src/app/doctor-onboarding/[token]/page.tsx
@@ -1,0 +1,507 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { motion } from "framer-motion";
+import { ArrowRight, Lock, AlertCircle, CheckCircle2 } from "lucide-react";
+
+import { DoctorForm, type DoctorFormPayload } from "@/components/admin/doctor-form";
+import { Button } from "@/components/primitives/button";
+import { Card } from "@/components/primitives/card";
+import { Input, Label } from "@/components/primitives/input";
+import { SectionLabel } from "@/components/primitives/section-label";
+import { ApiError, api } from "@/lib/api";
+import { explainError } from "@/lib/error-codes";
+import { fadeIn, fadeInUp, staggerTight } from "@/lib/motion";
+
+// Peek response:
+//   mode "new"      → email + optional familyName hint. Doctor fills full profile.
+//   mode "rotation" → email + givenName + familyName. Doctor just rotates pw.
+type PeekResponse = {
+  mode: "new" | "rotation";
+  email: string;
+  familyName?: string | null;
+  givenName?: string | null;
+};
+
+const MIN_PASSWORD_LEN = 8;
+
+type PageState =
+  | { mode: "loading" }
+  | { mode: "invalid"; reason: string }
+  | { mode: "ready"; peek: PeekResponse }
+  | { mode: "submitted_rotation" }
+  | { mode: "submitted_new" };
+
+export default function DoctorOnboardingPage() {
+  const params = useParams<{ token: string }>();
+  const token = Array.isArray(params.token) ? params.token[0] : params.token;
+  const router = useRouter();
+
+  const [state, setState] = useState<PageState>({ mode: "loading" });
+
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const peek = await api<PeekResponse>(`/doctor-onboarding/${token}`, {
+          skipAuthRedirect: true,
+        });
+        if (!cancelled) setState({ mode: "ready", peek });
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && (err.status === 404 || err.status === 409)) {
+          setState({ mode: "invalid", reason: explainError(err.error) });
+        } else {
+          setState({
+            mode: "invalid",
+            reason: "Couldn't reach the server. Try again in a moment.",
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return (
+    <main className="relative min-h-screen overflow-hidden">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute -left-32 top-0 h-[520px] w-[520px] rounded-full bg-[var(--accent)]/[0.04] blur-[150px]" />
+        <div className="absolute -right-32 bottom-0 h-[520px] w-[520px] rounded-full bg-[var(--accent-secondary)]/[0.05] blur-[150px]" />
+      </div>
+
+      <div className="absolute inset-x-0 top-0 z-10 px-6 py-6 sm:px-8">
+        <div className="mx-auto flex max-w-6xl items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] shadow-accent">
+              <span className="font-display text-lg leading-none text-white">H</span>
+            </div>
+            <span className="font-display text-xl tracking-[-0.01em]">HapuTele</span>
+          </div>
+          <span className="hidden font-mono text-xs uppercase tracking-[0.15em] text-[var(--muted-foreground)] sm:block">
+            Practitioner onboarding
+          </span>
+        </div>
+      </div>
+
+      <div
+        className={`mx-auto flex min-h-screen ${
+          state.mode === "ready" && state.peek.mode === "new"
+            ? "max-w-4xl items-start"
+            : "max-w-2xl items-center"
+        } justify-center px-6 py-24 sm:px-8`}
+      >
+        {state.mode === "loading" && <LoadingPanel />}
+        {state.mode === "invalid" && <InvalidPanel reason={state.reason} />}
+        {state.mode === "submitted_rotation" && (
+          <SuccessPanel
+            title="Password set."
+            message="Taking you to the sign-in page…"
+            redirectTo="/login"
+          />
+        )}
+        {state.mode === "submitted_new" && (
+          <SuccessPanel
+            title="Submitted for review."
+            message="An administrator will review your profile shortly. You'll be able to sign in once it's approved."
+            redirectTo="/login"
+            redirectDelayMs={3500}
+          />
+        )}
+        {state.mode === "ready" && state.peek.mode === "rotation" && (
+          <RotationPanel
+            token={token}
+            peek={state.peek}
+            onDone={() => setState({ mode: "submitted_rotation" })}
+            onInvalid={(reason) => setState({ mode: "invalid", reason })}
+          />
+        )}
+        {state.mode === "ready" && state.peek.mode === "new" && (
+          <NewDoctorPanel
+            token={token}
+            peek={state.peek}
+            onDone={() => setState({ mode: "submitted_new" })}
+            onInvalid={(reason) => setState({ mode: "invalid", reason })}
+          />
+        )}
+      </div>
+    </main>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Loading / invalid / success
+ * ────────────────────────────────────────────────────────────────── */
+
+function LoadingPanel() {
+  return (
+    <span className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+      Checking your invitation…
+    </span>
+  );
+}
+
+function InvalidPanel({ reason }: { reason: string }) {
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={staggerTight}
+      className="flex max-w-md flex-col items-start gap-6"
+    >
+      <motion.div variants={fadeInUp}>
+        <SectionLabel className="border-rose-300/40 bg-rose-100/40">
+          <span className="text-rose-700">Invite unavailable</span>
+        </SectionLabel>
+      </motion.div>
+      <motion.div variants={fadeInUp} className="flex items-start gap-3">
+        <AlertCircle className="mt-1 h-6 w-6 flex-shrink-0 text-rose-600" />
+        <h1 className="font-display text-3xl leading-tight tracking-[-0.02em] sm:text-4xl">
+          This link can&rsquo;t be used.
+        </h1>
+      </motion.div>
+      <motion.p
+        variants={fadeIn}
+        className="text-base leading-relaxed text-[var(--muted-foreground)]"
+      >
+        {reason}
+      </motion.p>
+    </motion.div>
+  );
+}
+
+function SuccessPanel({
+  title,
+  message,
+  redirectTo,
+  redirectDelayMs = 1800,
+}: {
+  title: string;
+  message: string;
+  redirectTo: string;
+  redirectDelayMs?: number;
+}) {
+  const router = useRouter();
+  useEffect(() => {
+    const t = setTimeout(() => router.replace(redirectTo), redirectDelayMs);
+    return () => clearTimeout(t);
+  }, [router, redirectTo, redirectDelayMs]);
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={staggerTight}
+      className="flex max-w-md flex-col items-start gap-6"
+    >
+      <motion.div variants={fadeInUp}>
+        <SectionLabel pulse>Submitted</SectionLabel>
+      </motion.div>
+      <motion.div variants={fadeInUp} className="flex items-start gap-3">
+        <CheckCircle2 className="mt-1 h-6 w-6 flex-shrink-0 text-emerald-600" />
+        <h1 className="font-display text-3xl leading-tight tracking-[-0.02em] sm:text-4xl">
+          {title}
+        </h1>
+      </motion.div>
+      <motion.p
+        variants={fadeIn}
+        className="text-base leading-relaxed text-[var(--muted-foreground)]"
+      >
+        {message}
+      </motion.p>
+    </motion.div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * Rotation: just a password
+ * ────────────────────────────────────────────────────────────────── */
+
+function RotationPanel({
+  token,
+  peek,
+  onDone,
+  onInvalid,
+}: {
+  token: string;
+  peek: PeekResponse;
+  onDone: () => void;
+  onInvalid: (reason: string) => void;
+}) {
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (password.length < MIN_PASSWORD_LEN) {
+      setError(`Choose a password at least ${MIN_PASSWORD_LEN} characters long.`);
+      return;
+    }
+    if (password !== confirm) {
+      setError("Passwords don't match. Re-enter to confirm.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api(`/doctor-onboarding/${token}`, {
+        method: "POST",
+        body: { password },
+        skipAuthRedirect: true,
+      });
+      onDone();
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 409)) {
+        onInvalid(explainError(err.error));
+      } else if (err instanceof ApiError) {
+        setError(explainError(err.error));
+      } else {
+        setError("Couldn't reach the server. Try again in a moment.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={staggerTight}
+      className="flex w-full max-w-md flex-col gap-7"
+    >
+      <motion.div variants={fadeInUp}>
+        <SectionLabel pulse>Invite verified</SectionLabel>
+      </motion.div>
+
+      <motion.h1
+        variants={fadeInUp}
+        className="font-display text-[2.5rem] leading-[1.05] tracking-[-0.02em] sm:text-5xl"
+      >
+        Welcome,{" "}
+        <span className="gradient-text">
+          Dr. {peek.familyName ?? ""}
+        </span>
+        .
+      </motion.h1>
+
+      <motion.p
+        variants={fadeInUp}
+        className="text-base leading-relaxed text-[var(--muted-foreground)]"
+      >
+        Set a password to finish setting up your account.
+      </motion.p>
+
+      <motion.form
+        variants={fadeInUp}
+        onSubmit={onSubmit}
+        className="flex w-full flex-col gap-4"
+      >
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="password">New password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            placeholder={`At least ${MIN_PASSWORD_LEN} characters`}
+            minLength={MIN_PASSWORD_LEN}
+            autoFocus
+            required
+          />
+        </div>
+
+        <div className="flex flex-col gap-2">
+          <Label htmlFor="confirm">Confirm password</Label>
+          <Input
+            id="confirm"
+            type="password"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            required
+          />
+        </div>
+
+        {error && (
+          <motion.div
+            role="alert"
+            initial={{ opacity: 0, y: -4 }}
+            animate={{ opacity: 1, y: 0 }}
+            className="flex items-start gap-2 rounded-xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700"
+          >
+            <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+            <span>{error}</span>
+          </motion.div>
+        )}
+
+        <Button type="submit" size="lg" disabled={submitting} className="w-full sm:w-auto">
+          <Lock className="h-4 w-4" />
+          {submitting ? "Setting password…" : "Set password & continue"}
+          <ArrowRight className="h-4 w-4 transition-transform group-hover:translate-x-1" />
+        </Button>
+      </motion.form>
+
+      <motion.p variants={fadeIn} className="text-sm text-[var(--muted-foreground)]">
+        Trouble signing in? Contact your administrator.
+      </motion.p>
+    </motion.div>
+  );
+}
+
+/* ──────────────────────────────────────────────────────────────────
+ * New doctor: full §1.7 profile form
+ * ────────────────────────────────────────────────────────────────── */
+
+function NewDoctorPanel({
+  token,
+  peek,
+  onDone,
+  onInvalid,
+}: {
+  token: string;
+  peek: PeekResponse;
+  onDone: () => void;
+  onInvalid: (reason: string) => void;
+}) {
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [errorMissing, setErrorMissing] = useState<string[] | undefined>(undefined);
+
+  const onSubmit = async (payload: DoctorFormPayload) => {
+    setErrorMessage(null);
+    setErrorMissing(undefined);
+    if (!payload.password || payload.password.length < MIN_PASSWORD_LEN) {
+      setErrorMessage(`Choose a password at least ${MIN_PASSWORD_LEN} characters long.`);
+      return;
+    }
+    if (!payload.username) {
+      setErrorMessage("Pick a username.");
+      return;
+    }
+    if (!payload.rubberStampImage) {
+      setErrorMessage("Upload your rubber-stamp image.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      await api(`/doctor-onboarding/${token}`, {
+        method: "POST",
+        body: {
+          // Intentionally no `email` — the invite owns that value and
+          // the server uses invite.email when creating the Doctor row.
+          // Sending one here would just get dropped by the schema.
+          username: payload.username,
+          password: payload.password,
+          givenName: payload.givenName,
+          familyName: payload.familyName,
+          contact: payload.contact,
+          slmcRegistrationNumber: payload.slmcRegistrationNumber,
+          qualifications: payload.qualifications,
+          practitionerAddress: payload.practitionerAddress,
+          instituteName: payload.instituteName,
+          instituteContact: payload.instituteContact,
+          rubberStampImage: payload.rubberStampImage,
+        },
+        skipAuthRedirect: true,
+      });
+      onDone();
+    } catch (err) {
+      if (err instanceof ApiError && (err.status === 404 || err.status === 409)) {
+        onInvalid(explainError(err.error));
+      } else if (err instanceof ApiError) {
+        if (err.error === "missing_prescription_fields") {
+          setErrorMissing(err.detail?.missing as string[] | undefined);
+          setErrorMessage(
+            "Some §1.7 mandatory fields couldn't be validated server-side.",
+          );
+        } else {
+          setErrorMessage(explainError(err.error));
+        }
+      } else {
+        setErrorMessage("Couldn't reach the server. Try again in a moment.");
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <motion.div
+      initial="hidden"
+      animate="visible"
+      variants={staggerTight}
+      className="flex w-full flex-col gap-7"
+    >
+      <motion.div variants={fadeInUp}>
+        <SectionLabel pulse>Invite verified</SectionLabel>
+      </motion.div>
+
+      <motion.h1
+        variants={fadeInUp}
+        className="font-display text-[2.5rem] leading-[1.05] tracking-[-0.02em] sm:text-5xl"
+      >
+        {peek.familyName ? <>Welcome, <span className="gradient-text">Dr. {peek.familyName}</span>.</> : <>Set up your <span className="gradient-text">HapuTele</span> account.</>}
+      </motion.h1>
+
+      <motion.p
+        variants={fadeInUp}
+        className="max-w-2xl text-base leading-relaxed text-[var(--muted-foreground)]"
+      >
+        Fill in your full profile below. Once you submit, an administrator
+        will review your information before activating your account. You
+        won&rsquo;t be able to sign in until that approval comes through.
+      </motion.p>
+
+      {/* Email is fixed by the invite — show read-only for clarity. */}
+      <motion.div variants={fadeInUp}>
+        <Card className="flex items-center justify-between gap-3 border-[var(--accent)]/20 bg-[var(--accent)]/[0.04] p-4">
+          <div>
+            <div className="font-mono text-[11px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+              Invitation email
+            </div>
+            <div className="mt-1 text-sm">{peek.email}</div>
+          </div>
+          <span className="rounded-full bg-[var(--accent)]/10 px-2.5 py-1 font-mono text-[10px] uppercase tracking-[0.12em] text-[var(--accent)]">
+            Locked
+          </span>
+        </Card>
+      </motion.div>
+
+      <motion.div variants={fadeInUp}>
+        <Card variant="elevated" className="p-6 sm:p-8">
+          <DoctorForm
+            mode="create"
+            // Pass the invited email so the form's email field is pre-filled
+            // (the read-only locking happens via the embedded layout below).
+            initial={{
+              id: 0,
+              username: "",
+              givenName: "",
+              familyName: peek.familyName ?? "",
+              contact: "",
+              email: peek.email,
+              slmcRegistrationNumber: "",
+              qualifications: "",
+              practitionerAddress: "",
+              instituteName: "",
+              instituteContact: "",
+              active: true,
+            }}
+            embedded="self-onboarding"
+            submitting={submitting}
+            errorMessage={errorMessage}
+            errorMissingFields={errorMissing}
+            submitLabel="Submit for review"
+            onSubmit={onSubmit}
+          />
+        </Card>
+      </motion.div>
+    </motion.div>
+  );
+}

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -75,7 +75,10 @@ function LoginScreen() {
     } catch (err) {
       // Backend returns a stable `invalid_credentials` code regardless of
       // which field was wrong, so the error never leaks user existence.
-      if (err instanceof ApiError && err.status === 401) {
+      // The pending-approval / rejected codes come back as 403 — those
+      // are intentionally specific because only the legitimate owner
+      // ever sees them (you have to have entered the right password).
+      if (err instanceof ApiError && (err.status === 401 || err.status === 403)) {
         setError(explainError(err.error));
       } else {
         setError("Couldn't reach the server. Try again in a moment.");

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
 import { z } from "zod";
-import { BadgeCheck, ContactRound, IdCard, Stamp } from "lucide-react";
+import { BadgeCheck, ContactRound, IdCard, Mail, Stamp } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
 import { ErrorBanner } from "@/components/primitives/error-banner";
@@ -27,11 +27,17 @@ const baseFields = {
   instituteContact: z.string().min(1, "Institute contact is required (§1.7)"),
 };
 
+// Password validity now depends on `onboardingMode`. Zod can't peek at
+// React state, so the schema treats password as optional and the submit
+// handler enforces "manual mode → password required". Keeps zod working
+// for everything else while the mode toggle drives the password rule.
 const createSchema = z.object({
   ...baseFields,
   username: z.string().min(1, "Username is required"),
-  password: z.string().min(1, "Password is required"),
+  password: z.string().optional(),
 });
+
+type OnboardingMode = "invite" | "manual";
 
 const updateSchema = z.object({
   ...baseFields,
@@ -56,6 +62,7 @@ export type DoctorFormPayload = {
 export function DoctorForm({
   initial,
   mode,
+  embedded,
   submitting,
   errorMessage,
   errorMissingFields,
@@ -63,8 +70,13 @@ export function DoctorForm({
   onSubmit,
   onCancel,
 }: {
-  initial?: Doctor | null;
+  initial?: Partial<Doctor> | null;
   mode: "create" | "update";
+  // "self-onboarding" hides the admin-only onboarding-mode toggle and
+  // requires both a username and a password (the doctor is creating
+  // their own login). Default (undefined) gives the regular admin
+  // experience with the toggle.
+  embedded?: "self-onboarding";
   submitting: boolean;
   errorMessage?: string | null;
   errorMissingFields?: string[];
@@ -73,6 +85,7 @@ export function DoctorForm({
   onCancel?: () => void;
 }) {
   const isCreate = mode === "create";
+  const isSelfOnboarding = embedded === "self-onboarding";
   type Values = z.infer<typeof createSchema>;
   // In update mode we seed the uploader from the existing stamp so admins see
   // what's on file (Stamp captured / Replace / Clear). `stampDirty` flips on any
@@ -81,6 +94,13 @@ export function DoctorForm({
   const [stamp, setStamp] = useState<string | null>(initial?.rubberStampImage ?? null);
   const [stampDirty, setStampDirty] = useState(false);
   const [stampError, setStampError] = useState<string | null>(null);
+  // Onboarding-mode picker. "invite" (default) tells the backend to email
+  // the doctor a link to set their own password. "manual" preserves the
+  // legacy flow — admin types the password and shares it offline. Only
+  // shown in create mode; in edit mode the password input keeps its
+  // existing "rotate password" semantics.
+  const [onboardingMode, setOnboardingMode] = useState<OnboardingMode>("invite");
+  const [passwordError, setPasswordError] = useState<string | null>(null);
 
   const handleStampChange = (next: string | null) => {
     setStamp(next);
@@ -114,6 +134,26 @@ export function DoctorForm({
       return;
     }
     setStampError(null);
+    // Mode-dependent password validation. Manual mode → must be present.
+    // Invite mode → must NOT be sent (backend reads its absence as the
+    // "issue an invite" signal). Edit mode keeps the legacy "leave blank
+    // to keep" semantics regardless of the toggle (toggle isn't shown).
+    // In self-onboarding mode the doctor MUST provide both username
+    // and password; in admin-create mode the toggle decides.
+    if (
+      isCreate
+      && !isSelfOnboarding
+      && onboardingMode === "manual"
+      && (!v.password || !v.password.trim())
+    ) {
+      setPasswordError("Password is required when sharing credentials manually.");
+      return;
+    }
+    if (isCreate && isSelfOnboarding && (!v.password || !v.password.trim())) {
+      setPasswordError("Pick a password.");
+      return;
+    }
+    setPasswordError(null);
     const stampToSend = isCreate ? stamp : stampDirty && stamp ? stamp : null;
     const payload: DoctorFormPayload = {
       givenName: v.givenName.trim(),
@@ -129,7 +169,13 @@ export function DoctorForm({
     };
     if (isCreate) {
       payload.username = v.username?.trim();
-      payload.password = v.password;
+      if (isSelfOnboarding) {
+        // Self-onboarding: password is always sent (validated above).
+        payload.password = v.password;
+      } else if (onboardingMode === "manual" && v.password) {
+        payload.password = v.password;
+      }
+      // admin invite mode → payload.password stays undefined; backend fires invite
     } else if (v.password && v.password.trim()) {
       payload.password = v.password;
     }
@@ -161,16 +207,47 @@ export function DoctorForm({
           <Field label="Family name *" htmlFor="familyName" error={errors.familyName?.message}>
             <Input id="familyName" {...register("familyName")} />
           </Field>
-          <Field label="Email *" htmlFor="email" error={errors.email?.message}>
-            <Input id="email" type="email" {...register("email")} />
-          </Field>
+          {/* In self-onboarding mode the email is owned by the invite, not
+              the form — the page renders a locked email card above. We
+              hide this field entirely so there's nothing for the user to
+              fight with and nothing the client could try to forge. The
+              register() call still runs so react-hook-form's defaultValue
+              for `email` is present in the values dict, but it isn't
+              read by any submit path in self-onboarding mode. */}
+          {!isSelfOnboarding && (
+            <Field label="Email *" htmlFor="email" error={errors.email?.message}>
+              <Input
+                id="email"
+                type="email"
+                {...register("email")}
+              />
+            </Field>
+          )}
           <Field label="Contact number *" htmlFor="contact" error={errors.contact?.message}>
-            <Input id="contact" {...register("contact")} placeholder="+94…" />
+            <Input id="contact" autoComplete="off" {...register("contact")} placeholder="+94…" />
           </Field>
         </div>
       </Section>
 
-      <Section Icon={IdCard} title={isCreate ? "Login credentials" : "Login credentials (rotate password)"}>
+      <Section Icon={IdCard} title="Login credentials">
+        {isCreate && !isSelfOnboarding && (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <ModeCard
+              Icon={Mail}
+              title="Send invite email"
+              description="Doctor receives a link to set their own password. Recommended."
+              selected={onboardingMode === "invite"}
+              onClick={() => setOnboardingMode("invite")}
+            />
+            <ModeCard
+              Icon={IdCard}
+              title="Set password manually"
+              description="Type a password and share it with the doctor offline."
+              selected={onboardingMode === "manual"}
+              onClick={() => setOnboardingMode("manual")}
+            />
+          </div>
+        )}
         <div className="grid gap-4 sm:grid-cols-2">
           {isCreate ? (
             <Field label="Username *" htmlFor="username" error={errors.username?.message}>
@@ -184,14 +261,26 @@ export function DoctorForm({
               </div>
             </div>
           )}
-          <Field
-            label={isCreate ? "Password *" : "New password (leave blank to keep)"}
-            htmlFor="password"
-            error={errors.password?.message}
-          >
-            <Input id="password" type="password" {...register("password")} autoComplete="new-password" />
-          </Field>
+          {/* Show password in: update mode, manual create mode, and always
+              in self-onboarding mode (the doctor picks their own). Hidden
+              in admin "invite" create mode since the doctor will set it
+              via the onboarding link. */}
+          {(!isCreate || isSelfOnboarding || onboardingMode === "manual") && (
+            <Field
+              label={isCreate ? "Password *" : "New password (leave blank to keep)"}
+              htmlFor="password"
+              error={passwordError ?? errors.password?.message}
+            >
+              <Input id="password" type="password" {...register("password")} autoComplete="new-password" />
+            </Field>
+          )}
         </div>
+        {isCreate && !isSelfOnboarding && onboardingMode === "invite" && (
+          <p className="mt-2 text-xs text-[var(--muted-foreground)]">
+            On save, the doctor receives an invite at the email above. The link
+            expires in 72 hours; you can re-send from the doctor&rsquo;s detail page.
+          </p>
+        )}
       </Section>
 
       <Section
@@ -199,26 +288,31 @@ export function DoctorForm({
         title="Sri Lanka §1.7 prescription requirements"
         hint="These five fields plus the rubber stamp are reproduced verbatim on every prescription PDF this doctor signs. They're required at account creation."
       >
+        {/* autoComplete="off" everywhere in this section — browsers see
+            field ids like "practitionerAddress" / "instituteName" and
+            confidently autofill them with the user's home address /
+            employer, which is wrong for a clinic profile. The doctor
+            should type these fields explicitly. */}
         <div className="grid gap-4 sm:grid-cols-2">
           <Field
             label="SLMC registration number *"
             htmlFor="slmcRegistrationNumber"
             error={errors.slmcRegistrationNumber?.message}
           >
-            <Input id="slmcRegistrationNumber" {...register("slmcRegistrationNumber")} />
+            <Input id="slmcRegistrationNumber" autoComplete="off" {...register("slmcRegistrationNumber")} />
           </Field>
           <Field label="Institute name *" htmlFor="instituteName" error={errors.instituteName?.message}>
-            <Input id="instituteName" {...register("instituteName")} />
+            <Input id="instituteName" autoComplete="off" {...register("instituteName")} />
           </Field>
           <Field
             label="Institute contact *"
             htmlFor="instituteContact"
             error={errors.instituteContact?.message}
           >
-            <Input id="instituteContact" {...register("instituteContact")} />
+            <Input id="instituteContact" autoComplete="off" {...register("instituteContact")} />
           </Field>
           <Field label="Qualifications *" htmlFor="qualifications" full error={errors.qualifications?.message}>
-            <Textarea id="qualifications" rows={3} {...register("qualifications")} placeholder="e.g. MBBS, MD" />
+            <Textarea id="qualifications" rows={3} autoComplete="off" {...register("qualifications")} placeholder="e.g. MBBS, MD" />
           </Field>
           <Field
             label="Practitioner address *"
@@ -226,7 +320,7 @@ export function DoctorForm({
             full
             error={errors.practitionerAddress?.message}
           >
-            <Textarea id="practitionerAddress" rows={3} {...register("practitionerAddress")} />
+            <Textarea id="practitionerAddress" rows={3} autoComplete="off" {...register("practitionerAddress")} />
           </Field>
         </div>
       </Section>
@@ -276,6 +370,50 @@ function Section({
     </section>
   );
 }
+
+function ModeCard({
+  Icon,
+  title,
+  description,
+  selected,
+  onClick,
+}: {
+  Icon: typeof BadgeCheck;
+  title: string;
+  description: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`flex items-start gap-3 rounded-xl border p-4 text-left transition-all ${
+        selected
+          ? "border-[var(--accent)] bg-[var(--accent)]/5 shadow-sm"
+          : "border-[var(--border)] bg-transparent hover:border-[var(--accent)]/40"
+      }`}
+    >
+      <div
+        className={`rounded-lg p-2 ${
+          selected ? "bg-[var(--accent)]/15" : "bg-[var(--muted)]"
+        }`}
+      >
+        <Icon
+          className={`h-4 w-4 ${
+            selected ? "text-[var(--accent)]" : "text-[var(--muted-foreground)]"
+          }`}
+        />
+      </div>
+      <div className="flex flex-col gap-1">
+        <span className="text-sm font-semibold">{title}</span>
+        <span className="text-xs leading-snug text-[var(--muted-foreground)]">{description}</span>
+      </div>
+    </button>
+  );
+}
+
 
 function Field({
   label,

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -55,6 +55,27 @@ const MESSAGES: Record<string, string> = {
   setup_address_required: "Provide at least one institute address line.",
   setup_institute_name_required: "Institute name is required.",
   setup_institute_phone_required: "Institute contact phone is required.",
+  // Doctor invite / onboarding flow.
+  invite_not_found:
+    "This invite link isn't valid. It may have expired or already been used. Ask your administrator to resend a new one.",
+  password_too_short: "Choose a password at least 8 characters long.",
+  missing_password: "Choose a password.",
+  email_not_configured:
+    "Email isn't set up on the server, so an invite can't be sent. Ask an administrator to either configure the email service or create the account with a manual password.",
+  email_already_used:
+    "A doctor account or pending invite already uses that email address.",
+  email_mismatch:
+    "The email in the form has to match the one your invite was sent to.",
+  wrong_invite_mode:
+    "This invite link is for a different onboarding flow. Ask your admin to resend it.",
+  account_pending_approval:
+    "Your account hasn't been approved by an administrator yet. Please wait — you'll get an email once it's reviewed.",
+  account_rejected:
+    "Your onboarding submission was rejected. Contact your administrator for details.",
+  doctor_rejected:
+    "This doctor's submission was previously rejected. Re-issue an invite to start fresh.",
+  doctor_already_approved:
+    "This doctor is already approved. Use deactivate instead if you want to disable them.",
   request_failed: "Something went wrong. Try again.",
 };
 

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -194,7 +194,10 @@ export function useDoctor(id: number | null) {
 
 export type DoctorCreateRequest = {
   username: string;
-  password: string;
+  // Optional: when omitted the backend mints an invite token and emails the
+  // doctor a link to set their own password. Requires the email service to
+  // be configured server-side; otherwise the request 422s `email_not_configured`.
+  password?: string;
   givenName: string;
   familyName: string;
   contact: string;
@@ -226,6 +229,56 @@ export function useUpdateDoctor(id: number) {
     onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
   });
 }
+
+// Fires the doctor invite email again. Any prior live invite for the same
+// doctor is revoked inside the backend `services.doctor_invites.issue()`,
+// so the old link stops working as soon as this resolves.
+export function useReissueDoctorInvite() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<void, ApiError, number>({
+    mutationFn: (id) => fetcher(`/doctors/${id}/invites`, { method: "POST" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
+  });
+}
+
+// Invite-by-email: admin types just the email and (optionally) a name
+// hint. No Doctor row is created server-side until the doctor consumes
+// the invite via the public onboarding form.
+export type DoctorInviteRequest = { email: string; familyName?: string };
+export type DoctorInviteResponse = { inviteId: number; email: string };
+
+export function useInviteDoctor() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<DoctorInviteResponse, ApiError, DoctorInviteRequest>({
+    mutationFn: (body) => fetcher("/doctors/invites", { method: "POST", body }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
+  });
+}
+
+// Approve / reject a self-onboarded doctor. Approve flips status →
+// "active". Reject stamps rejected_at + sets active=false; supply a
+// reason that's surfaced on the rejected doctor's login screen.
+export function useApproveDoctor() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<Doctor, ApiError, number>({
+    mutationFn: (id) => fetcher(`/doctors/${id}/approve`, { method: "POST" }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
+  });
+}
+
+export function useRejectDoctor() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<Doctor, ApiError, { id: number; reason?: string }>({
+    mutationFn: ({ id, reason }) =>
+      fetcher(`/doctors/${id}/reject`, { method: "POST", body: { reason } }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
+  });
+}
+
 
 // Soft-delete — backend sets active=false, preserves FK references on past
 // appointments / consultations.

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -75,6 +75,13 @@ export type Doctor = {
   instituteName: string;
   instituteContact: string;
   active: boolean;
+  // Four-state lifecycle (server-computed):
+  //   awaiting_setup    → live unconsumed invite, no form submission yet
+  //   awaiting_approval → doctor self-onboarded; admin needs to act
+  //   rejected          → admin reviewed + rejected
+  //   active            → approved + usable
+  // Optional for backward compatibility with older response shapes.
+  onboardingStatus?: "awaiting_setup" | "awaiting_approval" | "rejected" | "active";
   // Only the singular GET /doctors/{id} populates this (as a base64 data URL);
   // the list endpoint omits it to keep payloads lean.
   rubberStampImage?: string | null;


### PR DESCRIPTION
## Summary
- **Resend email infrastructure**: `services/email.py` with suppression filtering, Jinja2 templating, tag sanitisation, optional `scheduled_at` + `Idempotency-Key`. Webhook handler at `/resend/webhook` (Svix-verified, dormant until `RESEND_WEBHOOK_SECRET` is set).
- **Invite-by-email doctor onboarding**: admin types only an email at `/admin/doctors/new`; the doctor self-onboards via `/doctor-onboarding/<token>` with the full §1.7 profile + their own credentials. Server uses `invite.email` exclusively — the client can't influence the address.
- **Admin approval workflow**: self-onboarded doctors land in `awaiting_approval`. Admin can approve (fires "your account is approved" email) or reject with a reason that's surfaced on the doctor's blocked login. Login refuses `account_pending_approval` / `account_rejected` until cleared.
- **Legacy paths preserved**: `POST /doctors` with full payload still works (admin-typed credentials). "Create manually" is the second option in the admin's add-doctor mode picker.
- **Admin UX**: per-doctor `onboardingStatus` (4-state) drives badges on the doctor list and contextual banners on the detail page (`awaiting_setup` → Re-send invite, `awaiting_approval` → Approve/Reject, `rejected` → terminal).

### Backend additions

- 3 new alembic migrations: `0009_email_suppressions`, `0010_email_invites_and_log`, `0011_invite_email_approval`. Linear chain on top of `0008_blobs_to_s3`.
- New tables: `email_suppressions`, `doctor_invites` (with nullable `doctor_id`, `email`, optional `family_name` hint), `notification_log`.
- New columns on `doctor`: `approved_at`, `rejected_at`, `rejected_reason`. Existing rows backfilled to approved.
- New services: `services/email.py`, `services/doctor_invites.py`.
- New routers: `routers/doctor_onboarding.py`, `routers/resend_webhook.py`.
- New schemas: `DoctorOnboardingPeek` (mode-discriminated), `DoctorOnboardingSubmit` (no email field — invite owns it), `DoctorInviteCreate`, `DoctorRejectIn`.
- Updated `routers/doctors.py`: `POST /doctors/invites`, `POST /doctors/{id}/approve`, `POST /doctors/{id}/reject`, plus `onboardingStatus` plumbing into list + detail returns.
- Updated `routers/auth.py`: login refuses unapproved doctors with `account_pending_approval` / `account_rejected`.
- Healthworker booking list filters out unapproved/rejected doctors; admin sees everyone.
- Email templates: `base.html`, `doctor_invite.html/.txt` (mode-aware: rotation vs new), `doctor_approved.html/.txt`.

### Frontend additions

- `/admin/doctors/new` mode picker (Invite by email · Create manually).
- `/admin/doctors/[id]`: awaiting_approval banner with Approve / Reject buttons, reject modal with reason input, awaiting_setup banner with Re-send affordance, rejected terminal state.
- `/admin` doctor list with 4-state status badges.
- `/doctor-onboarding/[token]` page with mode-branched UI (rotation = slim password panel; new = full §1.7 profile form).
- Login page surfaces `account_pending_approval` / `account_rejected`.
- `DoctorForm` extended with `embedded="self-onboarding"` for the doctor-facing flow; admin mode toggle hidden in that case.
- Error-codes table updated.

### Tests

- 89 backend tests passing — covers email service (render + suppression + tag sanitiser + scheduled_at + idempotency_key passthrough), invite service (issue/lookup/consume/reissue, both rotation + new modes), invite API, onboarding API (peek + complete, password length, single-use), invite-by-email + approval flow (admin invites → doctor submits → status flips → approve unlocks login → reject blocks login with reason).
- Frontend `tsc --noEmit` clean; `next build` succeeds on Next 15.5.18.

### Migration to S3 storage layer

Rubber-stamp upload in the doctor self-onboarding path now goes through `services.storage.put_bytes()` + stores `rubber_stamp_key`, consistent with the recent S3-blobs PR.

## Test plan
- [ ] `docker compose up --build -d` from a clean state — all 11 migrations apply, all 4 containers (db, rustfs, api, frontend) healthy
- [ ] Walk first-run `/setup`, log in as sys-admin
- [ ] Seed an admin via the sys-admin UI (or DB), log in as admin
- [ ] **Admin invite flow**: `/admin/doctors/new` → "Invite by email" → type a real email → "Send invite". Inbox receives the "You're invited to HapuTele" email.
- [ ] **Doctor self-onboarding**: click invite link → see locked email card + full §1.7 form → submit → "Submitted for review" screen
- [ ] **Login blocked**: doctor's login attempt returns `account_pending_approval`
- [ ] **Admin sees `awaiting_approval`** banner on the doctor's detail page with §1.7 fields populated for review
- [ ] **Approve** → "Your HapuTele account is approved" email lands in doctor's inbox; status flips to `active`; doctor login succeeds
- [ ] **Reject path**: invite a second doctor, onboard them, reject with a reason → login attempt returns `account_rejected` with the reason
- [ ] **Re-send invite**: on `awaiting_setup` banner → click Re-send → old link 404s, new link works
- [ ] **Legacy "Create manually"** path still works (admin types everything; doctor active immediately)
- [ ] Frontend: rubber-stamp upload during doctor self-onboarding writes to S3 (visible in rustfs console at http://localhost:9001) and re-displays correctly on the admin detail page after approval

🤖 Generated with [Claude Code](https://claude.com/claude-code)