### PR TITLE
fix(deployment): write SSH key via bash launch script, not cloud-init

### DIFF
--- a/deployment/templates/user-data.sh.tpl
+++ b/deployment/templates/user-data.sh.tpl
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Lightsail launch script (user_data). Runs once as root at first boot.
+#
+# We deliberately do NOT use a #cloud-config here: Lightsail does not reliably
+# apply cloud-init's ssh_authorized_keys / default-user modules, so the key
+# never lands in admin's authorized_keys and Ansible can't connect. A plain
+# bash script is the mechanism Lightsail runs dependably (and cloud-init, if
+# present, also executes #! user-data scripts), so it works either way.
+#
+# Both heredocs are quoted ('PUBKEY' / 'VAULT') so the shell does not expand
+# anything inside them — critical for the vault ciphertext, which contains a
+# literal "$ANSIBLE_VAULT" marker.
+set -euo pipefail
+
+# --- SSH access for Ansible (Debian's default Lightsail user is "admin") ---
+install -d -m 0700 -o admin -g admin /home/admin/.ssh
+cat > /home/admin/.ssh/authorized_keys <<'PUBKEY'
+${public_key}
+PUBKEY
+chown admin:admin /home/admin/.ssh/authorized_keys
+chmod 600 /home/admin/.ssh/authorized_keys
+
+# --- Encrypted secrets, decrypted later by the Ansible playbook ---
+install -d -m 0755 /etc/haputele
+cat > /etc/haputele/vault.yml <<'VAULT'
+${vault_ciphertext}
+VAULT
+chown root:root /etc/haputele/vault.yml
+chmod 600 /etc/haputele/vault.yml

--- a/deployment/vm.tf
+++ b/deployment/vm.tf
@@ -4,31 +4,29 @@ resource "aws_lightsail_instance" "debian_vm" {
   blueprint_id      = "debian_13"
   bundle_id         = "small_3_1"
 
-  # Cloud-init is now intentionally minimal: it only authorizes the SSH key
-  # (so Ansible can connect) and drops the ansible-vault-encrypted secrets file
-  # on disk. Everything else — Docker install, directories, rendering config and
+  # A plain bash launch script (NOT #cloud-config): it authorizes the SSH key so
+  # Ansible can connect, and drops the ansible-vault-encrypted secrets file on
+  # disk. Everything else — Docker install, directories, rendering config and
   # bringing up the docker compose stack — is done by the Ansible playbook
-  # (deployment/ansible/), which runs as a separate CI step. Debian 12 already
-  # ships python3, so Ansible needs nothing more at boot.
+  # (deployment/ansible/), which runs as a separate CI step.
   #
-  # Built with yamlencode (not a hand-indented heredoc) because the vault
-  # ciphertext is multi-line and whitespace-sensitive — yamlencode guarantees a
-  # byte-exact round-trip when cloud-init reads the `content` value back.
+  # Why not cloud-init: Lightsail does not reliably apply cloud-init's
+  # ssh_authorized_keys / default-user modules, so a valid #cloud-config leaves
+  # admin's authorized_keys empty and Ansible's SSH wait loop never connects
+  # (Permission denied (publickey), even on a freshly built VM). The script
+  # writes the key into /home/admin/.ssh directly. templatefile keeps the
+  # multi-line vault ciphertext byte-exact (no HCL heredoc indentation to mangle
+  # it).
   #
-  # SECURITY: cloud-init user_data is retrievable from the instance metadata
-  # endpoint and stored in Terraform state. The file written below is
-  # ansible-vault ciphertext (see vault.tf), so it stays encrypted at rest both
-  # here and on the VM disk. Changing any secret changes the ciphertext, which
-  # (user_data being ForceNew) replaces the VM — rotate secrets deliberately.
-  user_data = "#cloud-config\n${yamlencode({
-    ssh_authorized_keys = [tls_private_key.vm_key.public_key_openssh]
-    write_files = [{
-      path        = "/etc/haputele/vault.yml"
-      owner       = "root:root"
-      permissions = "0600"
-      content     = data.external.vault.result.ciphertext
-    }]
-  })}"
+  # SECURITY: user_data is retrievable from the instance metadata endpoint and
+  # stored in Terraform state. The secrets file written below is ansible-vault
+  # ciphertext (see vault.tf), so it stays encrypted at rest both here and on
+  # the VM disk. Changing any secret changes the ciphertext, which (user_data
+  # being ForceNew) replaces the VM — rotate secrets deliberately.
+  user_data = templatefile("${path.module}/templates/user-data.sh.tpl", {
+    public_key       = trimspace(tls_private_key.vm_key.public_key_openssh)
+    vault_ciphertext = data.external.vault.result.ciphertext
+  })
 
   tags = {
     Name = "debian-vm"


### PR DESCRIPTION
## Problem
The **Wait for VM SSH** step in the Deployment workflow fails with `admin@<ip>: Permission denied (publickey)` on every attempt — and it keeps failing even on a **brand-new VM** after a full `destroy` + `apply` (the public IP changed). That rules out both a stale leftover VM and cloud-init timing.

## Root cause
**Lightsail does not reliably apply cloud-init's `ssh_authorized_keys` / default-user modules.** The `#cloud-config` user_data renders valid YAML (verified with `yamlencode`) and the key itself is correct, but it never ends up in `admin`'s `authorized_keys`, so SSH auth is rejected and the deploy can't reach the Ansible provisioning step.

## Fix
Replace the `#cloud-config` user_data with a plain `#!/bin/bash` launch script (`templates/user-data.sh.tpl`) that:
- writes the public key straight into `/home/admin/.ssh/authorized_keys` (mode 0600, owned by `admin`), and
- drops the ansible-vault secrets file at `/etc/haputele/vault.yml`.

A bash launch script is the mechanism Lightsail runs dependably, and cloud-init (if present) also executes `#!` user-data — so it works either way. `templatefile` keeps the multi-line vault ciphertext byte-exact (no HCL heredoc indentation to mangle it).

`user_data` stays `ForceNew`, so applying this **replaces the VM** with a correctly-keyed one.

## Verification
- `terraform fmt -check` passes.
- Rendered the script with sample inputs: `#!/bin/bash` first line, key on its own line inside a quoted heredoc, vault ciphertext intact (incl. the literal `$ANSIBLE_VAULT` marker).
- `debian_13` / `small_3_1` from `main` preserved.

## After merge
Run the Deployment workflow with **intent: apply** (from `main`). The VM is replaced; the SSH wait loop should connect within a minute. Note the rebuilt VM gets a **new public IP** — update the `haputele.sightprojects.app` DNS A record afterwards (needed later for Caddy's TLS cert, not for the SSH step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)