### PR TITLE
feat(deployment): allocate a Lightsail static IP for a stable address

### DIFF
--- a/deployment/outputs.tf
+++ b/deployment/outputs.tf
@@ -1,5 +1,9 @@
+# The static IP, not aws_lightsail_instance.public_ip_address: the latter can
+# still report the old dynamic address until the attachment settles, and it
+# changes on every rebuild. This is the address to point DNS at — it's stable.
 output "vm_public_ip" {
-  value = aws_lightsail_instance.debian_vm.public_ip_address
+  value      = aws_lightsail_static_ip.vm.ip_address
+  depends_on = [aws_lightsail_static_ip_attachment.vm]
 }
 
 output "public_url" {

--- a/deployment/static_ip.tf
+++ b/deployment/static_ip.tf
@@ -1,0 +1,13 @@
+# A Lightsail static IP so the public address survives VM rebuilds. Without this,
+# Lightsail assigns a new dynamic IP every time the instance is replaced (any
+# user_data/secret change is ForceNew), which would mean re-pointing DNS after
+# every deploy. The static IP is allocated once and re-attached to whatever
+# instance currently exists, so DNS is set a single time.
+resource "aws_lightsail_static_ip" "vm" {
+  name = "haputele-static-ip"
+}
+
+resource "aws_lightsail_static_ip_attachment" "vm" {
+  static_ip_name = aws_lightsail_static_ip.vm.name
+  instance_name  = aws_lightsail_instance.debian_vm.name
+}


### PR DESCRIPTION
## Why
Lightsail hands out a **new dynamic public IP every time the VM is rebuilt** (and any `user_data`/secret change is `ForceNew`, so rebuilds are common). That means the `haputele.sightprojects.app` DNS record would have to be updated after *every* deploy — we already cycled through three IPs (`13.206.196.77 → 15.206.28.31 → 15.206.67.170`) just while debugging the SSH issue.

## What
- Allocate an `aws_lightsail_static_ip` and attach it to the instance.
- The static IP is independent of the instance, so its address is **stable across rebuilds**; the attachment just re-binds it to the current instance.
- `vm_public_ip` now outputs the static IP (with `depends_on` the attachment) so the CI SSH step and DNS both use the stable address.

## After merge
1. Run the Deployment workflow → **apply**.
2. Read the static IP from the run (or `terraform output -raw vm_public_ip`).
3. Set the `haputele.sightprojects.app` **A record → that IP, one time**. It won't change on future deploys.

Verified: `terraform fmt -check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)