### PR TITLE
feat(deployment): authorize operator SSH keys on the VM

### DIFF
--- a/deployment/templates/user-data.sh.tpl
+++ b/deployment/templates/user-data.sh.tpl
@@ -16,6 +16,7 @@ set -euo pipefail
 install -d -m 0700 -o admin -g admin /home/admin/.ssh
 cat > /home/admin/.ssh/authorized_keys <<'PUBKEY'
 ${public_key}
+${extra_authorized_keys}
 PUBKEY
 chown admin:admin /home/admin/.ssh/authorized_keys
 chmod 600 /home/admin/.ssh/authorized_keys

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -194,3 +194,14 @@ variable "next_public_app_timezone" {
   type        = string
   default     = "Asia/Colombo"
 }
+
+variable "extra_authorized_keys" {
+  description = "Additional SSH public keys authorized for the 'admin' user, appended after the Terraform-generated VM key. Default: operator keys from https://github.com/0xinterface.keys."
+  type        = list(string)
+  default = [
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3XtOQIWQXzJBMwKZAHj+CdStqUfLqTn80zoIYHqpMY",
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL4hoqAr76JwTIlUXjR1kMeIfRifij65hBN5vlK7bfco",
+    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHPK+bR2JIzK43k8rGILOlJ07YaymhHoXcpjR69ngqoC",
+    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG2h8OBT7O/X4jmyfKfODDrl84cjpcjbC7Ge3B4eoJf0EgVSqHjl7TK8MojnxjivoQl7kZGNHeoMJ/jUqSJqGW4=",
+  ]
+}

--- a/deployment/vm.tf
+++ b/deployment/vm.tf
@@ -24,8 +24,9 @@ resource "aws_lightsail_instance" "debian_vm" {
   # the VM disk. Changing any secret changes the ciphertext, which (user_data
   # being ForceNew) replaces the VM — rotate secrets deliberately.
   user_data = templatefile("${path.module}/templates/user-data.sh.tpl", {
-    public_key       = trimspace(tls_private_key.vm_key.public_key_openssh)
-    vault_ciphertext = data.external.vault.result.ciphertext
+    public_key            = trimspace(tls_private_key.vm_key.public_key_openssh)
+    extra_authorized_keys = join("\n", var.extra_authorized_keys)
+    vault_ciphertext      = data.external.vault.result.ciphertext
   })
 
   tags = {


### PR DESCRIPTION
Adds the operator SSH public keys from https://github.com/0xinterface.keys to the Lightsail VM's authorized keys, alongside the Terraform-generated VM key.

## Changes
- **`variables.tf`** — new `extra_authorized_keys` list variable, defaulting to the four keys from `0xinterface.keys`. Operators can override or clear it per-environment.
- **`vm.tf`** — passes the joined keys into the launch-script template.
- **`templates/user-data.sh.tpl`** — appends the extra keys after the VM key in `admin`'s `authorized_keys`.

## Notes
- `user_data` is `ForceNew`, so this only applies to a **freshly built VM**. It does not touch the `authorized_keys` of an already-running instance — that would need a manual/Ansible step.
- Of the four keys, three are `ssh-ed25519` and one is `ecdsa-sha2-nistp256` (the weaker keytype). Easy to drop the ECDSA one from the default if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)