### PR TITLE
fix(deployment): manage operator SSH keys via Ansible, not user_data

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -9,6 +9,18 @@
 # SSH login user for the Lightsail Debian 12 image.
 ansible_user: admin
 
+# Operator SSH public keys, added to the admin user's authorized_keys by the
+# playbook — NOT via Terraform user_data, which is ForceNew and would destroy
+# and rebuild the VM on any change. Managing them here means a key add/remove is
+# just a playbook re-run against the live host. Public keys are non-secret, so
+# they live in plain group_vars rather than the vault. Source:
+# https://github.com/0xinterface.keys
+operator_authorized_keys:
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3XtOQIWQXzJBMwKZAHj+CdStqUfLqTn80zoIYHqpMY"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL4hoqAr76JwTIlUXjR1kMeIfRifij65hBN5vlK7bfco"
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHPK+bR2JIzK43k8rGILOlJ07YaymhHoXcpjR69ngqoC"
+  - "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG2h8OBT7O/X4jmyfKfODDrl84cjpcjbC7Ge3B4eoJf0EgVSqHjl7TK8MojnxjivoQl7kZGNHeoMJ/jUqSJqGW4="
+
 # Container images.
 docker_image_backend: ghcr.io/sight-hkust/haputele-backend:latest
 docker_image_frontend: ghcr.io/sight-hkust/haputele-frontend:latest

--- a/deployment/ansible/playbook.yml
+++ b/deployment/ansible/playbook.yml
@@ -17,6 +17,21 @@
     vault_staged_path: "{{ playbook_dir }}/.vault.staged.yml"
 
   tasks:
+    # Authorize operator keys on the LIVE VM. Kept out of Terraform's user_data
+    # (ForceNew → VM replacement) on purpose: a managed block in admin's
+    # authorized_keys is idempotent and rebuild-free. The block markers fence off
+    # these keys so the Terraform-generated bootstrap key (written by user_data)
+    # is never touched. blockinfile is ansible-core, so no extra collection.
+    - name: Authorize operator SSH keys for {{ ansible_user }}
+      ansible.builtin.blockinfile:
+        path: "/home/{{ ansible_user }}/.ssh/authorized_keys"
+        create: true
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0600"
+        marker: "# {mark} ANSIBLE MANAGED — operator keys"
+        block: '{{ operator_authorized_keys | join("\n") }}'
+
     # The apt module needs python3-apt, which minimal Debian 12 cloud images may
     # lack. raw uses /bin/sh (no python deps) to bootstrap it before any apt task.
     - name: Bootstrap python3-apt

--- a/deployment/templates/user-data.sh.tpl
+++ b/deployment/templates/user-data.sh.tpl
@@ -16,7 +16,6 @@ set -euo pipefail
 install -d -m 0700 -o admin -g admin /home/admin/.ssh
 cat > /home/admin/.ssh/authorized_keys <<'PUBKEY'
 ${public_key}
-${extra_authorized_keys}
 PUBKEY
 chown admin:admin /home/admin/.ssh/authorized_keys
 chmod 600 /home/admin/.ssh/authorized_keys

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -194,14 +194,3 @@ variable "next_public_app_timezone" {
   type        = string
   default     = "Asia/Colombo"
 }
-
-variable "extra_authorized_keys" {
-  description = "Additional SSH public keys authorized for the 'admin' user, appended after the Terraform-generated VM key. Default: operator keys from https://github.com/0xinterface.keys."
-  type        = list(string)
-  default = [
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIO3XtOQIWQXzJBMwKZAHj+CdStqUfLqTn80zoIYHqpMY",
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL4hoqAr76JwTIlUXjR1kMeIfRifij65hBN5vlK7bfco",
-    "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHPK+bR2JIzK43k8rGILOlJ07YaymhHoXcpjR69ngqoC",
-    "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG2h8OBT7O/X4jmyfKfODDrl84cjpcjbC7Ge3B4eoJf0EgVSqHjl7TK8MojnxjivoQl7kZGNHeoMJ/jUqSJqGW4=",
-  ]
-}

--- a/deployment/vm.tf
+++ b/deployment/vm.tf
@@ -24,9 +24,8 @@ resource "aws_lightsail_instance" "debian_vm" {
   # the VM disk. Changing any secret changes the ciphertext, which (user_data
   # being ForceNew) replaces the VM — rotate secrets deliberately.
   user_data = templatefile("${path.module}/templates/user-data.sh.tpl", {
-    public_key            = trimspace(tls_private_key.vm_key.public_key_openssh)
-    extra_authorized_keys = join("\n", var.extra_authorized_keys)
-    vault_ciphertext      = data.external.vault.result.ciphertext
+    public_key       = trimspace(tls_private_key.vm_key.public_key_openssh)
+    vault_ciphertext = data.external.vault.result.ciphertext
   })
 
   tags = {


### PR DESCRIPTION
Follow-up to #15. That PR added the operator SSH keys (https://github.com/0xinterface.keys) to the VM through Terraform `user_data` — but `user_data` on `aws_lightsail_instance` is **`ForceNew`**, so every key change destroys and rebuilds the VM. This moves key management to Ansible so the instance is never replaced.

## What changed
- **Revert the `user_data` approach** (#15): drops the `extra_authorized_keys` Terraform variable, the `vm.tf` template wiring, and the template line. These three files now match what they were before #15.
- **`ansible/group_vars/all.yml`** — `operator_authorized_keys` list (the four keys). Public keys are non-secret → plain group_vars, not the vault.
- **`ansible/playbook.yml`** — a `blockinfile` task writes those keys as a *managed block* in `admin`'s `authorized_keys`.

## Why this is safe
- Ansible runs over SSH against the **live VM** (existing post-apply CI step), so a key add/remove is just a playbook re-run — no VM replacement.
- The block markers fence the operator keys off from the Terraform-generated **bootstrap key** that `user_data` still writes, so that key is never disturbed.
- `blockinfile` is **ansible-core** — no new collection (CI only installs ansible-core; `ansible.cfg` deliberately avoids collections).
- Idempotent: removing a key from the list removes it from the VM on the next run.

## Note
Of the four keys, three are `ssh-ed25519` and one is `ecdsa-sha2-nistp256` (the weaker keytype) — easy to drop from the list if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)