### PR TITLE
feat(deployment): set RESEND_FROM to enable transactional email

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -51,8 +51,10 @@ DOCTOR_INVITE_TTL_HOURS: "72"
 S3_REGION: auto
 S3_FORCE_PATH_STYLE: "true"
 
-# Email (api key + webhook secret are secret — see vault).
-RESEND_FROM: ""
+# Email (api key + webhook secret are secret — see vault). RESEND_FROM must be
+# on a Resend-verified domain; empty disables email. Reply-To stays empty (no
+# Reply-To header on no-reply transactional mail).
+RESEND_FROM: noreply@haputele.sightprojects.app
 RESEND_REPLY_TO: ""
 
 # Frontend (NEXT_PUBLIC_* are inlined at image build time; passed for parity).

--- a/deployment/variables.tf
+++ b/deployment/variables.tf
@@ -123,13 +123,13 @@ variable "s3_force_path_style" {
 }
 
 variable "resend_from" {
-  description = "Sender address for Resend emails"
+  description = "Sender address for Resend emails. Must be on a domain verified in the Resend dashboard, else Resend rejects the send. Empty disables email (the backend's is_configured() requires both this and RESEND_API_KEY)."
   type        = string
-  default     = ""
+  default     = "noreply@haputele.sightprojects.app"
 }
 
 variable "resend_reply_to" {
-  description = "Reply-To address for Resend emails"
+  description = "Reply-To address for Resend emails. Optional; left empty so no Reply-To header is sent (no-reply transactional mail)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
Prod showed "email service isn't set up" because `RESEND_FROM` was empty in `/opt/haputele/.env`. The backend gates on **both** secrets — `email.py:64`: `is_configured() = bool(RESEND_API_KEY and RESEND_FROM)` — so an empty `RESEND_FROM` disables email even though the API key is set, and every send raises `422 email_not_configured`.

## Change
- **`variables.tf`** — `resend_from` defaults to `noreply@haputele.sightprojects.app` (a Resend-verified domain). Flows through the `ansible_extra_vars` output → `vars.json` → `env.j2` into `/opt/haputele/.env`. (`vars.json` outranks `group_vars`, so the Terraform variable is the authoritative place.)
- **`ansible/group_vars/all.yml`** — `RESEND_FROM` updated to match, per the file's keep-in-sync convention.
- **Reply-To left empty** — `email.py:151` omits the header when unset; correct for no-reply mail.

## Takes effect after deploy
Needs a **Deployment** workflow run with `intent=apply` to re-render `/opt/haputele/.env`.

## Note on the webhook (separate concern)
`/resend/webhook` is **not** required to send email. It's an inbound channel where Resend posts `email.bounced`/`email.complained` events to maintain a suppression list. Skipping it = sends still work; `RESEND_WEBHOOK_SECRET` can stay empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)