### PR TITLE
feat(attachments): modal image preview + camera capture for uploads

### DIFF
--- a/frontend/src/components/admin/rubber-stamp-uploader.tsx
+++ b/frontend/src/components/admin/rubber-stamp-uploader.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { Pencil, Stamp, Upload, X } from "lucide-react";
+import { Camera, Pencil, Stamp, Upload, X } from "lucide-react";
 import { useRef, useState, type ChangeEvent } from "react";
 
 import { Button } from "@/components/primitives/button";
+import { CameraCaptureModal } from "@/components/primitives/camera-capture-modal";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { Modal } from "@/components/primitives/modal";
 import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
@@ -24,13 +25,12 @@ export function RubberStampUploader({
   const [error, setError] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [editorSource, setEditorSource] = useState<string | null>(null);
+  const [cameraOpen, setCameraOpen] = useState(false);
 
-  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+  // Validate then read a file → base64 data URL → open the editor. Shared by
+  // the file picker and the camera capture.
+  const processFile = (file: File) => {
     setError(null);
-    const file = e.target.files?.[0];
-    // Reset the input so picking the same file twice still triggers onChange.
-    e.target.value = "";
-    if (!file) return;
     if (!ACCEPTED.includes(file.type)) {
       setError("Use a PNG or JPEG.");
       return;
@@ -46,6 +46,13 @@ export function RubberStampUploader({
     };
     reader.onerror = () => setError("Couldn't read the file. Try again.");
     reader.readAsDataURL(file);
+  };
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    // Reset the input so picking the same file twice still triggers onChange.
+    e.target.value = "";
+    if (file) processFile(file);
   };
 
   return (
@@ -91,6 +98,15 @@ export function RubberStampUploader({
             </Button>
             <Button
               type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setCameraOpen(true)}
+            >
+              <Camera className="h-3.5 w-3.5" />
+              Take photo
+            </Button>
+            <Button
+              type="button"
               variant="ghost"
               size="sm"
               onClick={() => onChange(null)}
@@ -101,21 +117,33 @@ export function RubberStampUploader({
           </div>
         </div>
       ) : (
-        <button
-          type="button"
-          onClick={() => inputRef.current?.click()}
-          className="group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/30 px-6 py-10 transition-colors hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]"
-        >
-          <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-3 text-white shadow-accent transition-transform duration-300 group-hover:scale-110">
-            <Stamp className="h-5 w-5" />
-          </div>
-          <div className="text-center">
-            <div className="text-sm font-semibold tracking-[-0.01em]">Upload rubber stamp</div>
-            <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
-              PNG or JPEG · &lt; 1 MB · crop &amp; remove background after upload
+        <div className="flex flex-col gap-2">
+          <button
+            type="button"
+            onClick={() => inputRef.current?.click()}
+            className="group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/30 px-6 py-10 transition-colors hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]"
+          >
+            <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-3 text-white shadow-accent transition-transform duration-300 group-hover:scale-110">
+              <Stamp className="h-5 w-5" />
             </div>
-          </div>
-        </button>
+            <div className="text-center">
+              <div className="text-sm font-semibold tracking-[-0.01em]">Upload rubber stamp</div>
+              <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+                PNG or JPEG · &lt; 1 MB · crop &amp; remove background after upload
+              </div>
+            </div>
+          </button>
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            className="self-center"
+            onClick={() => setCameraOpen(true)}
+          >
+            <Camera className="h-3.5 w-3.5" />
+            Take a photo instead
+          </Button>
+        </div>
       )}
       <input
         ref={inputRef}
@@ -160,6 +188,15 @@ export function RubberStampUploader({
           />
         )}
       </Modal>
+
+      <CameraCaptureModal
+        open={cameraOpen}
+        onClose={() => setCameraOpen(false)}
+        onCapture={processFile}
+        maxDimension={1280}
+        quality={0.9}
+        filename="rubber-stamp.jpg"
+      />
     </div>
   );
 }

--- a/frontend/src/components/doctor/patient-summary.tsx
+++ b/frontend/src/components/doctor/patient-summary.tsx
@@ -175,7 +175,7 @@ function DoctorAttachmentThumb({
             onClose={() => setPreview(false)}
             src={url}
             alt={attachment.caption || attachment.filename}
-            caption={attachment.caption}
+            title={attachment.caption || attachment.filename}
           />
         </>
       ) : error ? (

--- a/frontend/src/components/doctor/patient-summary.tsx
+++ b/frontend/src/components/doctor/patient-summary.tsx
@@ -1,8 +1,10 @@
 "use client";
 
+import { useState } from "react";
 import { Activity, Camera, ClipboardList, HeartPulse, MessageSquare, Pill } from "lucide-react";
 
 import { Card } from "@/components/primitives/card";
+import { ImagePreviewModal } from "@/components/primitives/image-preview-modal";
 import { ageFromDob, fmtDate } from "@/lib/format";
 import { diseaseLabel } from "@/lib/medical-codes";
 import { useAttachmentImage } from "@/lib/use-api";
@@ -150,17 +152,32 @@ function DoctorAttachmentThumb({
   appointmentId: number;
 }) {
   const { url, error } = useAttachmentImage(appointmentId, attachment.id);
+  const [preview, setPreview] = useState(false);
   return (
     <div className="aspect-square overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--muted)]/40">
       {url ? (
-        <a href={url} target="_blank" rel="noopener noreferrer" title={attachment.caption || attachment.filename}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
+        <>
+          <button
+            type="button"
+            onClick={() => setPreview(true)}
+            title={attachment.caption || attachment.filename}
+            className="block h-full w-full cursor-zoom-in"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={url}
+              alt={attachment.caption || attachment.filename}
+              className="h-full w-full object-cover transition-transform hover:scale-[1.02]"
+            />
+          </button>
+          <ImagePreviewModal
+            open={preview}
+            onClose={() => setPreview(false)}
             src={url}
             alt={attachment.caption || attachment.filename}
-            className="h-full w-full object-cover transition-transform hover:scale-[1.02]"
+            caption={attachment.caption}
           />
-        </a>
+        </>
       ) : error ? (
         <div className="flex h-full w-full items-center justify-center p-2 text-center text-[10px] text-rose-600">
           Load failed

--- a/frontend/src/components/healthworker/attachments-panel.tsx
+++ b/frontend/src/components/healthworker/attachments-panel.tsx
@@ -4,6 +4,7 @@ import { useRef, useState } from "react";
 import { Camera, Trash2, Upload } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
+import { CameraCaptureModal } from "@/components/primitives/camera-capture-modal";
 import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { ImagePreviewModal } from "@/components/primitives/image-preview-modal";
@@ -31,15 +32,16 @@ export function AttachmentsPanel({
   const list = useAttachments(appointmentId);
   const upload = useUploadAttachment(appointmentId);
   const [uploadError, setUploadError] = useState<string | null>(null);
+  const [cameraOpen, setCameraOpen] = useState(false);
 
   const readonly = READONLY_STATES.includes(status);
 
-  const handleFiles = async (files: FileList | null) => {
-    if (!files || files.length === 0) return;
+  const uploadFiles = async (files: File[]) => {
+    if (files.length === 0) return;
     setUploadError(null);
     // Sequential uploads — keeps the UI responsive and one bad file doesn't
     // abort the rest. The mutation hook invalidates the cache per success.
-    for (const file of Array.from(files)) {
+    for (const file of files) {
       try {
         await upload.mutateAsync({ file });
       } catch (err) {
@@ -48,6 +50,11 @@ export function AttachmentsPanel({
         break;
       }
     }
+  };
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return;
+    await uploadFiles(Array.from(files));
     if (fileInput.current) fileInput.current.value = "";
   };
 
@@ -66,14 +73,25 @@ export function AttachmentsPanel({
           </p>
         </div>
         {!readonly && (
-          <Button
-            onClick={() => fileInput.current?.click()}
-            disabled={upload.isPending}
-            size="sm"
-          >
-            <Upload className="h-3.5 w-3.5" />
-            {upload.isPending ? "Uploading…" : "Add photos"}
-          </Button>
+          <div className="flex shrink-0 gap-2">
+            <Button
+              variant="secondary"
+              onClick={() => setCameraOpen(true)}
+              disabled={upload.isPending}
+              size="sm"
+            >
+              <Camera className="h-3.5 w-3.5" />
+              Take photo
+            </Button>
+            <Button
+              onClick={() => fileInput.current?.click()}
+              disabled={upload.isPending}
+              size="sm"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              {upload.isPending ? "Uploading…" : "Add photos"}
+            </Button>
+          </div>
         )}
       </div>
 
@@ -104,6 +122,13 @@ export function AttachmentsPanel({
           No photos yet.
         </p>
       )}
+
+      <CameraCaptureModal
+        open={cameraOpen}
+        onClose={() => setCameraOpen(false)}
+        onCapture={(file) => uploadFiles([file])}
+        filename={`photo-${Date.now()}.jpg`}
+      />
     </Card>
   );
 }
@@ -145,7 +170,7 @@ function AttachmentThumb({
               onClose={() => setPreview(false)}
               src={url}
               alt={attachment.caption || attachment.filename}
-              caption={attachment.caption}
+              title={attachment.caption || attachment.filename}
             />
           </>
         ) : error ? (

--- a/frontend/src/components/healthworker/attachments-panel.tsx
+++ b/frontend/src/components/healthworker/attachments-panel.tsx
@@ -6,6 +6,7 @@ import { Camera, Trash2, Upload } from "lucide-react";
 import { Button } from "@/components/primitives/button";
 import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
+import { ImagePreviewModal } from "@/components/primitives/image-preview-modal";
 import { ApiError } from "@/lib/api";
 import { explainError } from "@/lib/error-codes";
 import {
@@ -119,19 +120,34 @@ function AttachmentThumb({
   const { url, error } = useAttachmentImage(appointmentId, attachment.id);
   const remove = useDeleteAttachment(appointmentId);
   const [confirming, setConfirming] = useState(false);
+  const [preview, setPreview] = useState(false);
 
   return (
     <div className="group relative overflow-hidden rounded-xl border border-[var(--border)] bg-[var(--muted)]/30">
       <div className="aspect-square w-full">
         {url ? (
-          <a href={url} target="_blank" rel="noopener noreferrer">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
+          <>
+            <button
+              type="button"
+              onClick={() => setPreview(true)}
+              title={attachment.caption || attachment.filename}
+              className="block h-full w-full cursor-zoom-in"
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={url}
+                alt={attachment.caption || attachment.filename}
+                className="h-full w-full object-cover"
+              />
+            </button>
+            <ImagePreviewModal
+              open={preview}
+              onClose={() => setPreview(false)}
               src={url}
               alt={attachment.caption || attachment.filename}
-              className="h-full w-full object-cover"
+              caption={attachment.caption}
             />
-          </a>
+          </>
         ) : error ? (
           <div className="flex h-full w-full items-center justify-center p-4 text-center text-xs text-rose-600">
             Couldn&rsquo;t load image.

--- a/frontend/src/components/primitives/camera-capture-modal.tsx
+++ b/frontend/src/components/primitives/camera-capture-modal.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Camera, Check, RefreshCw, SwitchCamera, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/primitives/button";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+
+// Live-camera capture as a popup window. Opens the device camera with
+// getUserMedia, lets the user snap a frame, review it, then hands back a JPEG
+// File via onCapture. Downscales to `maxDimension` so captures stay small.
+// Works anywhere a regular file upload does — both desktop webcams and mobile
+// front/back cameras (with a flip control when more than one is available).
+export function CameraCaptureModal({
+  open,
+  onClose,
+  onCapture,
+  maxDimension = 1920,
+  quality = 0.92,
+  filename = "photo.jpg",
+}: {
+  open: boolean;
+  onClose: () => void;
+  onCapture: (file: File) => void;
+  maxDimension?: number;
+  quality?: number;
+  filename?: string;
+}) {
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const fileRef = useRef<File | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const [error, setError] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [shot, setShot] = useState<string | null>(null);
+  const [facing, setFacing] = useState<"environment" | "user">("environment");
+  const [canSwitch, setCanSwitch] = useState(false);
+
+  const setShotUrl = (url: string | null) => {
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    objectUrlRef.current = url;
+    setShot(url);
+  };
+
+  // Esc to close + lock body scroll while open.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  // Start/stop the stream as the modal opens or the camera is flipped. We keep
+  // the stream live after a shot so "Retake" is instant.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setError(null);
+    setReady(false);
+
+    const start = async () => {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError("This device or browser doesn't support camera capture.");
+        return;
+      }
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: facing },
+          audio: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play().catch(() => {});
+        }
+        setReady(true);
+        navigator.mediaDevices
+          .enumerateDevices()
+          .then((ds) => {
+            if (!cancelled) {
+              setCanSwitch(ds.filter((d) => d.kind === "videoinput").length > 1);
+            }
+          })
+          .catch(() => {});
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof DOMException && err.name === "NotAllowedError"
+            ? "Camera access was blocked. Allow camera permission in your browser and try again."
+            : "Couldn't start the camera. Make sure no other app is using it.",
+        );
+      }
+    };
+    start();
+
+    return () => {
+      cancelled = true;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, [open, facing]);
+
+  // Reset the captured shot whenever the modal closes.
+  useEffect(() => {
+    if (!open) {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      objectUrlRef.current = null;
+      setShot(null);
+      fileRef.current = null;
+    }
+  }, [open]);
+
+  // Revoke any lingering object URL on unmount.
+  useEffect(
+    () => () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    },
+    [],
+  );
+
+  const capture = () => {
+    const video = videoRef.current;
+    if (!video || !video.videoWidth || !video.videoHeight) return;
+    const { videoWidth: vw, videoHeight: vh } = video;
+    const scale = Math.min(1, maxDimension / Math.max(vw, vh));
+    const cw = Math.round(vw * scale);
+    const ch = Math.round(vh * scale);
+    const canvas = document.createElement("canvas");
+    canvas.width = cw;
+    canvas.height = ch;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, cw, ch);
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          setError("Couldn't capture the photo. Try again.");
+          return;
+        }
+        fileRef.current = new File([blob], filename, { type: "image/jpeg" });
+        setShotUrl(URL.createObjectURL(blob));
+      },
+      "image/jpeg",
+      quality,
+    );
+  };
+
+  const retake = () => {
+    setShotUrl(null);
+    fileRef.current = null;
+  };
+
+  const usePhoto = () => {
+    if (fileRef.current) onCapture(fileRef.current);
+    onClose();
+  };
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
+          onClick={onClose}
+          role="dialog"
+          aria-modal
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.97 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">
+              <span className="text-sm font-medium text-[var(--foreground)]">Take a photo</span>
+              <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close camera">
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="flex flex-1 items-center justify-center overflow-hidden bg-black p-0">
+              <div className="relative flex aspect-[4/3] w-full items-center justify-center">
+                {/* Live preview — hidden once a shot is taken. */}
+                {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+                <video
+                  ref={videoRef}
+                  playsInline
+                  muted
+                  className={
+                    "h-full w-full object-contain " + (shot ? "hidden" : "block")
+                  }
+                />
+                {shot && (
+                  /* eslint-disable-next-line @next/next/no-img-element */
+                  <img src={shot} alt="Captured photo" className="h-full w-full object-contain" />
+                )}
+                {!ready && !shot && !error && (
+                  <div className="absolute inset-0 flex items-center justify-center text-sm text-white/70">
+                    Starting camera…
+                  </div>
+                )}
+              </div>
+            </div>
+
+            <div className="flex flex-col gap-3 p-4">
+              {error && <ErrorBanner>{error}</ErrorBanner>}
+              <div className="flex items-center justify-center gap-2">
+                {shot ? (
+                  <>
+                    <Button type="button" variant="secondary" onClick={retake}>
+                      <RefreshCw className="h-4 w-4" />
+                      Retake
+                    </Button>
+                    <Button type="button" onClick={usePhoto}>
+                      <Check className="h-4 w-4" />
+                      Use photo
+                    </Button>
+                  </>
+                ) : (
+                  <>
+                    {canSwitch && (
+                      <Button
+                        type="button"
+                        variant="secondary"
+                        size="icon"
+                        onClick={() => setFacing((f) => (f === "environment" ? "user" : "environment"))}
+                        aria-label="Switch camera"
+                      >
+                        <SwitchCamera className="h-4 w-4" />
+                      </Button>
+                    )}
+                    <Button type="button" onClick={capture} disabled={!ready}>
+                      <Camera className="h-4 w-4" />
+                      Capture
+                    </Button>
+                  </>
+                )}
+              </div>
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/primitives/image-preview-modal.tsx
+++ b/frontend/src/components/primitives/image-preview-modal.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { X } from "lucide-react";
+import { useEffect } from "react";
+
+import { Button } from "@/components/primitives/button";
+
+// Full-screen image lightbox — backdrop fade + image scale-in. Esc or backdrop
+// click to close. Mirrors the interaction model of the shared Modal but is
+// tailored for images: large object-contain preview with an optional caption,
+// so attachments open in-app instead of a raw new-tab file view.
+export function ImagePreviewModal({
+  open,
+  onClose,
+  src,
+  alt,
+  caption,
+}: {
+  open: boolean;
+  onClose: () => void;
+  src: string;
+  alt: string;
+  caption?: string | null;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open, onClose]);
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/60 p-4 backdrop-blur-sm sm:p-8"
+          onClick={onClose}
+          role="dialog"
+          aria-modal
+        >
+          <div className="absolute right-4 top-4 z-10">
+            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close preview">
+              <X className="h-5 w-5" />
+            </Button>
+          </div>
+          <motion.figure
+            initial={{ opacity: 0, scale: 0.96 }}
+            animate={{ opacity: 1, scale: 1 }}
+            exit={{ opacity: 0, scale: 0.97 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-full max-w-5xl flex-col items-center gap-3"
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={src}
+              alt={alt}
+              className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain shadow-2xl"
+            />
+            {caption && (
+              <figcaption className="max-w-full rounded-lg bg-[var(--card)]/90 px-3 py-1.5 text-center text-sm text-[var(--foreground)] shadow">
+                {caption}
+              </figcaption>
+            )}
+          </motion.figure>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/primitives/image-preview-modal.tsx
+++ b/frontend/src/components/primitives/image-preview-modal.tsx
@@ -6,22 +6,22 @@ import { useEffect } from "react";
 
 import { Button } from "@/components/primitives/button";
 
-// Full-screen image lightbox — backdrop fade + image scale-in. Esc or backdrop
-// click to close. Mirrors the interaction model of the shared Modal but is
-// tailored for images: large object-contain preview with an optional caption,
-// so attachments open in-app instead of a raw new-tab file view.
+// Image lightbox styled as a popup window — a framed panel with a header bar
+// (title + an explicit X close button) and the image in the body. Esc or
+// backdrop click also close. Used so attachments open in-app instead of a raw
+// new-tab file view.
 export function ImagePreviewModal({
   open,
   onClose,
   src,
   alt,
-  caption,
+  title,
 }: {
   open: boolean;
   onClose: () => void;
   src: string;
   alt: string;
-  caption?: string | null;
+  title?: string | null;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -42,36 +42,36 @@ export function ImagePreviewModal({
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
           transition={{ duration: 0.18 }}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/60 p-4 backdrop-blur-sm sm:p-8"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
           onClick={onClose}
           role="dialog"
           aria-modal
         >
-          <div className="absolute right-4 top-4 z-10">
-            <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close preview">
-              <X className="h-5 w-5" />
-            </Button>
-          </div>
-          <motion.figure
-            initial={{ opacity: 0, scale: 0.96 }}
-            animate={{ opacity: 1, scale: 1 }}
-            exit={{ opacity: 0, scale: 0.97 }}
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.97 }}
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
             onClick={(e) => e.stopPropagation()}
-            className="flex max-h-full max-w-5xl flex-col items-center gap-3"
+            className="flex max-h-full w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
           >
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img
-              src={src}
-              alt={alt}
-              className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain shadow-2xl"
-            />
-            {caption && (
-              <figcaption className="max-w-full rounded-lg bg-[var(--card)]/90 px-3 py-1.5 text-center text-sm text-[var(--foreground)] shadow">
-                {caption}
-              </figcaption>
-            )}
-          </motion.figure>
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">
+              <span className="truncate text-sm font-medium text-[var(--foreground)]" title={title ?? alt}>
+                {title ?? alt}
+              </span>
+              <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close preview">
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+            <div className="flex flex-1 items-center justify-center overflow-auto bg-[var(--muted)]/40 p-4">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={src}
+                alt={alt}
+                className="max-h-[78vh] w-auto max-w-full rounded-lg object-contain"
+              />
+            </div>
+          </motion.div>
         </motion.div>
       )}
     </AnimatePresence>


### PR DESCRIPTION
## Summary

Two related improvements to how pre-consultation / attachment images are viewed and added.

### 1. In-app modal preview (was: new browser tab)
Clicking an uploaded photo previously opened the raw image file in a new tab. It now opens an in-app **popup window** — a framed panel with a header bar and an explicit **X** close button (backdrop click / **Esc** also close).

- New reusable `ImagePreviewModal` primitive.
- Wired into the **doctor** patient summary (`DoctorAttachmentThumb`) and the **health worker** attachments panel (`AttachmentThumb`).

### 2. "Take photo" for image uploads (was: file picker only)
All image uploads can now capture directly from the device camera, in addition to file upload.

- New reusable `CameraCaptureModal` primitive: `getUserMedia` live preview → capture → review/retake → downscaled JPEG `File`. Front/back camera flip when more than one camera is available; graceful handling of permission-denied / no-camera; releases the camera on close.
- Wired into the **health worker attachments panel** (pre-consultation photos) and the **admin/doctor rubber stamp uploader** (capture feeds the existing crop/background-removal editor, downscaled to stay under the 1 MB stamp limit).

## Implementation notes
- No backend/API changes — capture reuses the existing attachment-upload and stamp `onChange` paths.
- `getUserMedia` requires a secure context, so the camera works over HTTPS (prod) and on `localhost`, but is blocked on plain-HTTP LAN IPs (browser security rule). `playsInline` + `muted` set for iOS Safari inline preview.

## Testing
- `npm run typecheck` — clean
- `npm run lint` — clean (only pre-existing warnings in unrelated `doctor-slot-picker.tsx`)
- Verified in local Docker stack: modal preview + "Take photo" render in the health worker cockpit and stamp uploader.

🤖 Generated with [Claude Code](https://claude.com/claude-code)