### PR TITLE
feat(deployment): versioned images + pinned, overridable prod deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,11 @@ on:
         description: "State lock ID to release (required when intent = unlock)"
         required: false
         default: ""
+      image_tag:
+        type: string
+        description: "Image tag to deploy, e.g. 0.1.0 or sha-abc1234 (emergency override; blank = use the terraform.tfvars pin)"
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -115,14 +120,32 @@ jobs:
             -d "{\"ID\":\"${LOCK_ID}\"}" \
             "${TF_HTTP_UNLOCK_ADDRESS}"
 
+      # An image_tag input overrides the terraform.tfvars pin for this run only.
+      # It's an ephemeral escape hatch (emergency rollback without a commit): the
+      # override lives in state until the next apply without it, which restores the
+      # tfvars pin. After using it, reconcile terraform.tfvars to match.
+      - name: Compute image override
+        id: img
+        run: |
+          TAG="${{ github.event.inputs.image_tag }}"
+          if [ -n "$TAG" ]; then
+            echo "Overriding image tag -> ${TAG}"
+            {
+              echo "vars=-var=docker_image_backend=ghcr.io/sight-hkust/haputele-backend:${TAG} -var=docker_image_frontend=ghcr.io/sight-hkust/haputele-frontend:${TAG}"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "No image_tag override; using terraform.tfvars pin."
+            echo "vars=" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Terraform Plan
         id: plan
         if: github.event.inputs.intent == 'plan'
-        run: terraform plan -no-color
+        run: terraform plan -no-color ${{ steps.img.outputs.vars }}
 
       - name: Terraform Apply
         if: github.ref == 'refs/heads/main' && github.event.inputs.intent == 'apply'
-        run: terraform apply -auto-approve
+        run: terraform apply -auto-approve ${{ steps.img.outputs.vars }}
 
       # --- Provision the VM with Ansible (apply only) ---
       - name: Wait for VM SSH + cloud-init

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,18 +3,17 @@ name: Build Docker images
 # Builds the frontend (Next.js) and backend (FastAPI) images in parallel.
 # PRs build both images for validation but do not push; pushes to main and
 # version tags (v*) publish to GitHub Container Registry.
+#
+# Path filtering lives in the `changes` job, NOT in `on.push.paths`: GitHub's
+# push path filter is unreliable for tag pushes (no well-defined base to diff
+# against), so a `paths` filter here would silently skip release (v*) builds.
+# We trigger on every push/PR and let the build job decide via its `if:`.
 on:
   push:
     branches: [main]
     tags: ['v*']
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
   pull_request:
     branches: [main]
-    paths:
-      - 'frontend/**'
-      - 'backend/**'
   workflow_dispatch:
 
 # Cancel an in-flight run when a newer commit lands on the same ref.
@@ -27,7 +26,33 @@ permissions:
   packages: write
 
 jobs:
+  # Detect whether app code changed. Used only to skip wasteful image rebuilds on
+  # infra-only branch pushes/PRs — tag and manual runs build unconditionally.
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      app: ${{ steps.filter.outputs.app }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            app:
+              - 'frontend/**'
+              - 'backend/**'
+
   build:
+    needs: changes
+    # Always build for version tags and manual runs; for branch pushes / PRs,
+    # build only when frontend/ or backend/ changed.
+    if: >-
+      github.ref_type == 'tag' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.app == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -57,6 +82,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ matrix.image }}
+          # latest=false: don't let semver tags auto-claim `latest`. We pin `latest`
+          # to main's tip via the raw rule below, so it stays a dev convenience and
+          # never silently becomes "the last release built". Production never uses
+          # `latest` — it pins an immutable :<semver> or :sha-<commit> (terraform.tfvars).
+          flavor: |
+            latest=false
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch

--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -1,0 +1,17 @@
+# Pinned production image versions — the source of truth for what runs in prod.
+#
+#   Release:  bump the tag here, open a PR, merge, then run the Deployment
+#             workflow (intent=apply). The running version is recorded in git.
+#   Rollback: `git revert` this change (or use the deploy workflow's `image_tag`
+#             input for an immediate, commit-free rollback).
+#
+# Terraform auto-loads terraform.tfvars, overriding the variable defaults. Always
+# pin an IMMUTABLE tag here — a semver release (:0.1.0) or a commit (:sha-abc1234).
+# Never :latest: it defeats reproducibility, and `terraform plan` can't show a diff
+# when its contents change out from under you.
+#
+# NOTE: the referenced tag must already exist in GHCR before you apply, or the
+# Ansible `docker compose pull` step fails. For a new semver, push the git tag and
+# wait for the "Build Docker images" workflow to go green first.
+docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.1.0"
+docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.1.0"


### PR DESCRIPTION
## Summary

Make production deploys **reproducible and rollback-able** instead of riding the floating `:latest` tag. Today `terraform apply` ships whatever happens to be tagged `:latest` in GHCR — so "what's in prod?" isn't answerable from the repo, rollback is manual, and `terraform plan` shows no diff when the image content changes underneath it.

This change pins the prod image version in git and gives the deploy workflow an override for emergency rollbacks.

## What changed

**Build — `.github/workflows/docker.yml`**
- **Fix: version-tag (`v*`) pushes now always build.** The old `on.push.paths` filter applied to tag pushes too, where GitHub's path filtering has no well-defined base to diff against — so release builds could be silently skipped. Path filtering moves into a `changes` gate job that only suppresses wasteful rebuilds on **infra-only branch/PR** pushes; **tags and manual runs always build**.
- `flavor: latest=false` so semver tags no longer auto-claim `latest`. `latest` stays pinned to main's tip — a dev convenience only; prod never uses it.
- `sha-<commit>` tags continue on every app build → an immutable rollback target for every commit.

**Deploy — `deployment/terraform.tfvars` (new) + `.github/workflows/deploy.yml`**
- `terraform.tfvars` pins the prod image versions in git (currently `0.1.0`). Release = bump + merge; rollback = `git revert`; the running version is now answerable from the repo.
- New `image_tag` workflow input overrides the pin **for that run only** (emergency rollback without a commit), wired through `-var` on both plan and apply. The override lives in state until the next un-overridden apply restores the tfvars pin.

## Does NOT rebuild the VM
The image tag flows only into the `ansible_extra_vars` **output**, never into the Lightsail `user_data` (which is `ForceNew`). Bumping the version is an output-only plan change; the new image is rolled out by the Ansible `docker compose pull` + `up -d` step (container swap, not infra replace).

## Bootstrap after merge (cuts v0.1.0)
~~~bash
git checkout main && git pull
git tag v0.1.0 && git push origin v0.1.0   # tag push builds :0.1.0, :0.1, :sha-<commit>
# wait for "Build Docker images" to go green, then run Deployment (intent=apply)
~~~
⚠️ `terraform.tfvars` references `:0.1.0`, which won't exist until the tag build completes — don't run apply before then (`docker compose pull` would fail).

## Notes / open questions
- First version assumed **`v0.1.0`** (pre-1.0). Trivial to switch to `v1.0.0`.
- Adds the `dorny/paths-filter@v3` action for the changes gate. Alternative: drop path filtering entirely (every main commit builds — simpler, more CI minutes, finer sha rollback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)