### PR TITLE
feat(deployment): authorize Daniel's laptop SSH key for operators

### DIFF
--- a/deployment/ansible/group_vars/all.yml
+++ b/deployment/ansible/group_vars/all.yml
@@ -20,6 +20,7 @@ operator_authorized_keys:
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIL4hoqAr76JwTIlUXjR1kMeIfRifij65hBN5vlK7bfco"
   - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIHPK+bR2JIzK43k8rGILOlJ07YaymhHoXcpjR69ngqoC"
   - "ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBG2h8OBT7O/X4jmyfKfODDrl84cjpcjbC7Ge3B4eoJf0EgVSqHjl7TK8MojnxjivoQl7kZGNHeoMJ/jUqSJqGW4="
+  - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIDUbBDuFv15fsHPXYgYDM4Ey/EW/lJoTzJtfvxdQ26X2" # Daniel's MacBook Air
 
 # Container images.
 docker_image_backend: ghcr.io/sight-hkust/haputele-backend:latest


### PR DESCRIPTION
## What

Adds Daniel's ed25519 public key to `operator_authorized_keys` in `deployment/ansible/group_vars/all.yml`.

## Why

So Daniel can SSH into the live VM as `admin`. The Ansible playbook's `blockinfile` task writes these keys into the admin user's `authorized_keys` (playbook.yml:25-33) — idempotent, no Terraform/VM rebuild. Public keys are non-secret, so they live in plain `group_vars` rather than the vault, matching the existing operator keys.

## Activating

After merge, manually run the **Deployment** workflow with intent = `apply` to push the key onto the live host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)