### PR TITLE
chore(deployment): pin prod images to v0.2.0

### DIFF
--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -13,5 +13,5 @@
 # NOTE: the referenced tag must already exist in GHCR before you apply, or the
 # Ansible `docker compose pull` step fails. For a new semver, push the git tag and
 # wait for the "Build Docker images" workflow to go green first.
-docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.1.0"
-docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.1.0"
+docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.2.0"
+docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.2.0"


### PR DESCRIPTION
Bumps the production image pin from `0.1.0` → `0.2.0`.

- Git tag `v0.2.0` was pushed on `302cfdf` (PR #21, sysadmin account management), triggering the **Build Docker images** workflow to publish `:0.2.0` to GHCR.
- This bumps `deployment/terraform.tfvars` to match.

**Before merging/applying:** confirm the `:0.2.0` images are green in GHCR (the Ansible `docker compose pull` step fails otherwise). After merge, run the **Deployment** workflow (intent=apply) to roll prod onto v0.2.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)