### PR TITLE
ci: gate Docker image build on backend pytest + frontend checks

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,33 +26,151 @@ permissions:
   packages: write
 
 jobs:
-  # Detect whether app code changed. Used only to skip wasteful image rebuilds on
-  # infra-only branch pushes/PRs — tag and manual runs build unconditionally.
+  # Detect which app code changed. Gates both the test jobs and the image
+  # rebuilds so infra-only branch pushes/PRs stay cheap — tag and manual runs
+  # test + build unconditionally.
   changes:
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     outputs:
-      app: ${{ steps.filter.outputs.app }}
+      backend: ${{ steps.filter.outputs.backend }}
+      frontend: ${{ steps.filter.outputs.frontend }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            app:
-              - 'frontend/**'
+            backend:
               - 'backend/**'
+            frontend:
+              - 'frontend/**'
 
-  build:
+  # Backend test gate: pytest against a real Postgres + S3 store.
+  #   - Postgres: the suite's conftest creates the test DB, runs Alembic
+  #     migrations, and wipes state per test. Without a reachable Postgres the
+  #     conftest SKIPS every test, so this service is what makes the DB tests a
+  #     real gate rather than a silent pass.
+  #   - rustfs (S3-compatible): the FastAPI lifespan calls ensure_bucket() on
+  #     startup, so every TestClient-based test fails with NoCredentialsError
+  #     unless an S3 endpoint is reachable. This mirrors the dev compose
+  #     `rustfs` service. (MinIO can't be used here — GitHub service containers
+  #     can't override the container command, and MinIO needs `server /data`;
+  #     rustfs is configured purely via env, so it works as a service.)
+  backend-test:
     needs: changes
-    # Always build for version tags and manual runs; for branch pushes / PRs,
-    # build only when frontend/ or backend/ changed.
     if: >-
       github.ref_type == 'tag' ||
       github.event_name == 'workflow_dispatch' ||
-      needs.changes.outputs.app == 'true'
+      needs.changes.outputs.backend == 'true'
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: hapu
+          POSTGRES_PASSWORD: hapu
+          POSTGRES_DB: haputele_test
+        ports:
+          - 5432:5432
+        # The job's steps don't start until these health checks pass, so
+        # Postgres is guaranteed reachable by the time pytest runs.
+        options: >-
+          --health-cmd "pg_isready -U hapu"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+      rustfs:
+        image: rustfs/rustfs:latest
+        env:
+          RUSTFS_VOLUMES: /data
+          RUSTFS_ADDRESS: 0.0.0.0:9000
+          RUSTFS_ACCESS_KEY: rustfsadmin
+          RUSTFS_SECRET_KEY: rustfsadmin
+          # rustfs refuses to boot with the default keys on a non-loopback
+          # listener unless this opt-out is set (dev/CI only — prod points at
+          # real S3). Mirrors docker-compose.yml.
+          RUSTFS_ALLOW_INSECURE_DEFAULT_CREDENTIALS: "true"
+          RUSTFS_OBS_LOGGER_LEVEL: warn
+        ports:
+          - 9000:9000
+        options: >-
+          --health-cmd "curl -fsS http://127.0.0.1:9000/health || exit 1"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements-dev.txt
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run pytest
+        env:
+          DATABASE_URL: postgresql+psycopg2://hapu:hapu@localhost:5432/haputele_test
+          # S3 store for the lifespan ensure_bucket() call (see job comment).
+          S3_ENDPOINT_URL: http://localhost:9000
+          S3_ACCESS_KEY_ID: rustfsadmin
+          S3_SECRET_ACCESS_KEY: rustfsadmin
+          S3_REGION: us-east-1
+          S3_BUCKET: haputele
+          S3_FORCE_PATH_STYLE: "true"
+        # Exit code 5 (no tests collected) fails the step, so a future rename
+        # that orphans tests/ can't slip through as a green build.
+        run: pytest tests/ -v
+
+  # Frontend check gate: lint + type-check. There is no unit-test runner yet
+  # (no jest/vitest); these are the cheapest meaningful gates the repo already
+  # supports. `next build` compile validation still happens in the build job.
+  frontend-checks:
+    needs: changes
+    if: >-
+      github.ref_type == 'tag' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        # --legacy-peer-deps matches the frontend Dockerfile: @fullcalendar
+        # has a known intra-package peer conflict (luxon3 wants core ~6.1.20,
+        # daygrid/timegrid want ~6.1.15) that strict npm ci rejects.
+        run: npm ci --legacy-peer-deps
+      - name: Lint
+        run: npm run lint
+      - name: Type-check
+        run: npm run typecheck
+
+  build:
+    needs: [changes, backend-test, frontend-checks]
+    # Gate the image build/push on the test jobs. `!cancelled() && !failure()`
+    # lets build run when a test job was SKIPPED (e.g. a frontend-only PR skips
+    # backend-test) while still blocking it when a test job actually FAILED —
+    # without the status functions, a skipped dependency would skip build too.
+    # Always build for version tags and manual runs; for branch pushes / PRs,
+    # build only when frontend/ or backend/ changed.
+    if: >-
+      !cancelled() && !failure() &&
+      (github.ref_type == 'tag' ||
+       github.event_name == 'workflow_dispatch' ||
+       needs.changes.outputs.backend == 'true' ||
+       needs.changes.outputs.frontend == 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## What

The **Build Docker images** workflow previously only built (and on `main`/tags pushed) the frontend/backend images — **no tests, lint, or type-checks ran**. A PR could go green and deploy with failing tests. This adds verification gates the image build now depends on.

## Changes

Two new gating jobs in `.github/workflows/docker.yml`, both required by `build`:

- **`backend-test`** — `pytest tests/` against `postgres:16` + `rustfs` service containers.
  - Postgres is required because the suite's `conftest` creates the test DB, runs Alembic migrations, and wipes state per test (it *skips* every test without a reachable DB — so the service is what makes it a real gate).
  - `rustfs` (S3-compatible) is required because the FastAPI lifespan calls `ensure_bucket()` on startup; without an S3 endpoint every `TestClient` test fails with `NoCredentialsError`. Mirrors the dev `docker-compose.yml`. (MinIO can't be used — GitHub service containers can't override the container command, and MinIO needs `server /data`; rustfs is env-only.)
- **`frontend-checks`** — `npm run lint` + `npm run typecheck`. Uses `npm ci --legacy-peer-deps` to match the frontend Dockerfile (known `@fullcalendar` peer conflict). No unit-test runner exists yet (no jest/vitest).

Supporting changes:
- Split the path filter into `backend`/`frontend` so each gate runs only when its code changed; tags and manual runs test unconditionally.
- `build` now `needs: [changes, backend-test, frontend-checks]` and uses `!cancelled() && !failure()` so a *skipped* test job (e.g. a frontend-only PR skips `backend-test`) still lets the build proceed, while an actual test **failure** blocks the build/push.

## Verification

Ran both gates locally against this branch (rebased on latest `main`, incl. the new sysadmin tests):
- Backend: **114 passed** (Postgres + rustfs).
- Frontend: `typecheck` clean; `lint` passes (warnings only).

## Follow-ups (not in this PR)

- To make these **required before merge**, add `backend-test` and `frontend-checks` as required status checks in `main`'s branch protection — CI jobs alone don't block merges.
- No frontend unit-test runner yet; adding Vitest is a separate task.
- `next lint` is deprecated (removed in Next 16); eventual migration to the ESLint CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)