### PR TITLE
feat(capture): scan-to-capture phone camera via QR

### DIFF
--- a/backend/alembic/versions/0012_capture_sessions.py
+++ b/backend/alembic/versions/0012_capture_sessions.py
@@ -1,0 +1,58 @@
+"""capture sessions (phone-as-camera via QR)
+
+Revision ID: 0012_capture_sessions
+Revises: 0011_invite_email_approval
+Create Date: 2026-06-07
+
+Adds the capture_sessions table backing the "scan a QR code to use your
+phone as a one-shot camera" flow. A logged-in operator mints a session,
+gets a raw token, and shows a QR encoding {FRONTEND_BASE_URL}/capture/
+{token}. The phone that scans it uploads photos straight to the server.
+
+We store only sha256-hex of the raw token (same pattern as setup_tokens
+and doctor_invites). `purpose` switches server behaviour on upload:
+
+  appointment_attachment → photo committed directly as an
+      appointment_attachments row on appointment_id (FK, ON DELETE
+      CASCADE so a deleted appointment takes its live sessions with it).
+  rubber_stamp → latest photo parked in the relay_* columns for the
+      desktop form to pull (no appointment_id).
+
+token_hash is UNIQUE so a lookup-by-hash is a single index hit. No
+separate liveness index — sessions are few and short-lived, and every
+lookup is by token_hash anyway.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0012_capture_sessions"
+down_revision: Union[str, None] = "0011_invite_email_approval"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS capture_sessions (
+            id                SERIAL PRIMARY KEY,
+            token_hash        VARCHAR(64) NOT NULL UNIQUE,
+            purpose           VARCHAR(30) NOT NULL,
+            appointment_id    INTEGER REFERENCES appointments(appointment_id) ON DELETE CASCADE,
+            created_by        VARCHAR(255) NOT NULL REFERENCES accounts(username),
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at        TIMESTAMPTZ NOT NULL,
+            closed_at         TIMESTAMPTZ,
+            upload_count      INTEGER NOT NULL DEFAULT 0,
+            relay_object_key  VARCHAR(512),
+            relay_mime        VARCHAR(50),
+            relay_uploaded_at TIMESTAMPTZ
+        )
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE IF EXISTS capture_sessions")

--- a/backend/alembic/versions/0015_capture_sessions.py
+++ b/backend/alembic/versions/0015_capture_sessions.py
@@ -1,7 +1,7 @@
 """capture sessions (phone-as-camera via QR)
 
-Revision ID: 0012_capture_sessions
-Revises: 0011_invite_email_approval
+Revision ID: 0015_capture_sessions
+Revises: 0014_doctor_status_audit
 Create Date: 2026-06-07
 
 Adds the capture_sessions table backing the "scan a QR code to use your
@@ -27,8 +27,8 @@ from typing import Sequence, Union
 from alembic import op
 
 
-revision: str = "0012_capture_sessions"
-down_revision: Union[str, None] = "0011_invite_email_approval"
+revision: str = "0015_capture_sessions"
+down_revision: Union[str, None] = "0014_doctor_status_audit"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -17,6 +17,7 @@ from .routers import (
     attachments,
     auth,
     availability,
+    capture,
     consultations,
     doctors,
     doctor_onboarding,
@@ -146,6 +147,7 @@ def create_app() -> FastAPI:
     app.include_router(availability.flat_router)
     app.include_router(preconsult.router)
     app.include_router(attachments.router)
+    app.include_router(capture.router)
     app.include_router(consultations.appts_router)
     app.include_router(consultations.cons_router)
     app.include_router(queue.router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -341,6 +341,62 @@ class DoctorInvite(Base):
     consumed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
 
 
+class CaptureSession(Base):
+    """Short-lived token that turns any phone into a one-shot camera.
+
+    A logged-in operator mints a session from the desktop (POST
+    /capture/sessions), gets back a raw token, and shows a QR code that
+    encodes `{FRONTEND_BASE_URL}/capture/{raw_token}`. Whoever scans it
+    lands on a public, token-authenticated page that drives the phone's
+    camera and uploads photos straight back here — the bytes never touch
+    the operator's computer.
+
+    Like setup_tokens / doctor_invites we store only sha256-hex of the raw
+    token; the raw value is shown once (in the QR) and never persisted.
+
+    `purpose` decides what the server does with an uploaded photo:
+
+      appointment_attachment → the photo is committed directly as an
+          AppointmentAttachment on `appointment_id`. Many photos per
+          session are allowed (the operator can snap several); the
+          desktop just watches the attachments list refresh.
+
+      rubber_stamp → there is no destination record yet (the stamp is a
+          field in a form still being filled out), so the latest photo is
+          parked in the relay slot below and the desktop pulls it into the
+          stamp editor. One photo at a time; a new upload overwrites.
+
+    Liveness: `closed_at IS NULL AND expires_at > NOW()`. The desktop
+    closes the session when the modal is dismissed; otherwise it lapses
+    on its short TTL.
+    """
+    __tablename__ = "capture_sessions"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    token_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+    purpose: Mapped[str] = mapped_column(String(30), nullable=False)
+    appointment_id: Mapped[int | None] = mapped_column(
+        Integer, ForeignKey("appointments.appointment_id", ondelete="CASCADE")
+    )
+    created_by: Mapped[str] = mapped_column(
+        String(255), ForeignKey("accounts.username"), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=text("NOW()")
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    closed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    upload_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default=text("0")
+    )
+    # Relay slot — only used by the rubber_stamp purpose. Holds the most
+    # recent uploaded photo until the desktop pulls it; overwritten on each
+    # new upload (the previous object is best-effort deleted).
+    relay_object_key: Mapped[str | None] = mapped_column(String(512))
+    relay_mime: Mapped[str | None] = mapped_column(String(50))
+    relay_uploaded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+
 class NotificationLog(Base):
     """Idempotency record for every outbound notification.
 

--- a/backend/app/routers/capture.py
+++ b/backend/app/routers/capture.py
@@ -1,0 +1,239 @@
+"""Phone-as-camera capture sessions — QR-driven, token-authenticated uploads.
+
+Two audiences share the `/capture` prefix:
+
+  Desktop (logged-in operator, cookie + CSRF auth)
+    POST   /capture/sessions            mint a session, get the raw token
+    GET    /capture/sessions/{id}       poll status (no token echoed)
+    GET    /capture/sessions/{id}/relay pull a parked rubber_stamp photo
+    DELETE /capture/sessions/{id}       close early (QR stops working)
+
+  Phone (whoever scanned the QR — the token IS the credential)
+    GET    /capture/{token}             peek: what is this capture for?
+    POST   /capture/{token}             upload a photo
+
+The phone endpoints intentionally bypass the session/CSRF stack, exactly
+like routers/doctor_onboarding.py: the scanner has no account and no
+cookie, and the unguessable 32-byte token is the whole credential.
+
+`purpose` decides what an upload becomes:
+  appointment_attachment → committed straight to the appointment as an
+      AppointmentAttachment (phone → server; never touches the desktop).
+  rubber_stamp → parked in the session's relay slot for the desktop form
+      to pull into its stamp editor (no destination record exists yet).
+
+Route declaration order matters: the literal `/sessions…` routes are
+declared before `/{token}` so a request to `/capture/sessions` can never
+be mis-parsed as a token named "sessions" (real tokens never are).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, File, Response, UploadFile, status
+from fastapi.concurrency import run_in_threadpool
+from sqlalchemy.orm import Session
+
+from ..deps import CurrentUser, current_user, db_dep
+from ..errors import conflict, forbidden, not_found, unprocessable
+from ..models import Appointment, AppointmentAttachment
+from ..schemas import (
+    CaptureSessionCreateIn,
+    CaptureSessionOut,
+    CaptureSessionStatusOut,
+    CapturePeekOut,
+)
+from ..services import capture
+from ..services.storage import delete_object, get_bytes, object_key, put_bytes
+# Reuse the exact validation surface the HW upload uses, so a photo that
+# would be accepted via "Add photos" is accepted via the phone too.
+from .attachments import ALLOWED_MIME, MAX_BYTES, WRITEABLE_STATES, _MIME_EXT
+
+
+_logger = logging.getLogger("haputele.capture")
+
+router = APIRouter(prefix="/capture", tags=["capture"])
+
+
+# ── Desktop (authenticated) ───────────────────────────────────────────
+
+@router.post(
+    "/sessions",
+    response_model=CaptureSessionOut,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_capture_session(
+    payload: CaptureSessionCreateIn,
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(current_user),
+) -> CaptureSessionOut:
+    """Mint a capture session. Role + target are validated per purpose so a
+    token can only ever do what the operator who minted it is allowed to do."""
+    if payload.purpose == "appointment_attachment":
+        # Mirror the HW-only write rule on attachments.
+        if user.role != "healthworker":
+            raise forbidden()
+        if payload.appointmentId is None:
+            raise unprocessable("appointment_required")
+        appt = db.get(Appointment, payload.appointmentId)
+        if appt is None:
+            raise not_found("appointment_not_found")
+        if appt.status not in WRITEABLE_STATES:
+            raise conflict("invalid_state", currentStatus=appt.status)
+        row, raw = capture.create_session(
+            db,
+            purpose=payload.purpose,
+            created_by=user.username,
+            appointment_id=payload.appointmentId,
+        )
+    else:  # rubber_stamp — used from the admin doctor form
+        if user.role != "admin":
+            raise forbidden()
+        row, raw = capture.create_session(
+            db, purpose=payload.purpose, created_by=user.username
+        )
+
+    _logger.info(
+        "capture session created: id=%s purpose=%s by=%s",
+        row.id, row.purpose, user.username,
+    )
+    return CaptureSessionOut(
+        id=row.id, token=raw, purpose=row.purpose, expiresAt=row.expires_at
+    )
+
+
+@router.get("/sessions/{session_id}", response_model=CaptureSessionStatusOut)
+def capture_session_status(
+    session_id: int,
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(current_user),
+) -> CaptureSessionStatusOut:
+    """Poll a session the caller owns. Never echoes the token."""
+    session = capture.get_owned(db, session_id=session_id, username=user.username)
+    now = datetime.now(timezone.utc)
+    return CaptureSessionStatusOut(
+        id=session.id,
+        purpose=session.purpose,
+        expiresAt=session.expires_at,
+        closed=session.closed_at is not None or session.expires_at <= now,
+        uploadCount=session.upload_count,
+        relayReady=session.relay_object_key is not None,
+    )
+
+
+@router.get("/sessions/{session_id}/relay")
+def pull_capture_relay(
+    session_id: int,
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(current_user),
+) -> Response:
+    """Pull the parked rubber_stamp photo into the desktop form, one-shot.
+
+    Clears the relay slot on read so a re-poll won't re-deliver the same
+    photo; the desktop loads the bytes into the stamp editor and then
+    closes the session.
+    """
+    session = capture.get_owned(db, session_id=session_id, username=user.username)
+    if session.purpose != "rubber_stamp" or not session.relay_object_key:
+        raise not_found("capture_relay_empty")
+    key = session.relay_object_key
+    mime = session.relay_mime or "image/jpeg"
+    data = get_bytes(key)
+    session.relay_object_key = None
+    session.relay_mime = None
+    session.relay_uploaded_at = None
+    db.commit()
+    delete_object(key)  # best-effort; row no longer references it
+    return Response(
+        content=data,
+        media_type=mime,
+        headers={"Cache-Control": "no-store"},
+    )
+
+
+@router.delete(
+    "/sessions/{session_id}",
+    status_code=status.HTTP_204_NO_CONTENT,
+    response_class=Response,
+)
+def close_capture_session(
+    session_id: int,
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(current_user),
+) -> Response:
+    """Close a session early so the QR stops working the moment the desktop
+    modal is dismissed, rather than lingering until the TTL."""
+    session = capture.get_owned(db, session_id=session_id, username=user.username)
+    capture.close(db, session)
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+# ── Phone (token-authenticated, no session/CSRF) ──────────────────────
+
+@router.get("/{token}", response_model=CapturePeekOut)
+def peek_capture(token: str, db: Session = Depends(db_dep)) -> CapturePeekOut:
+    """Validate the token and tell the phone page what it's capturing for.
+
+    404 `capture_session_not_found` covers unknown / closed / expired —
+    the page renders a generic "this link isn't active" screen.
+    """
+    session = capture.lookup_live(db, raw_token=token)
+    return CapturePeekOut(purpose=session.purpose, expiresAt=session.expires_at)
+
+
+@router.post("/{token}", status_code=status.HTTP_201_CREATED)
+async def upload_capture(
+    token: str,
+    file: UploadFile = File(...),
+    db: Session = Depends(db_dep),
+) -> dict:
+    """Accept a photo from the phone and route it by the session's purpose."""
+    session = capture.lookup_live(db, raw_token=token)
+
+    mime = (file.content_type or "").lower()
+    if mime not in ALLOWED_MIME:
+        raise unprocessable("attachment_unsupported_type", allowed=sorted(ALLOWED_MIME))
+    blob = await file.read()
+    if not blob:
+        raise unprocessable("attachment_empty")
+    if len(blob) > MAX_BYTES:
+        raise unprocessable("attachment_too_large", max=MAX_BYTES)
+
+    if session.purpose == "appointment_attachment":
+        appt = db.get(Appointment, session.appointment_id)
+        if appt is None or appt.status not in WRITEABLE_STATES:
+            raise conflict(
+                "invalid_state",
+                currentStatus=(appt.status if appt else None),
+            )
+        key = object_key(f"attachments/{session.appointment_id}", _MIME_EXT[mime])
+        await run_in_threadpool(put_bytes, key, blob, mime)
+        row = AppointmentAttachment(
+            appointment_id=session.appointment_id,
+            mime_type=mime,
+            filename=(file.filename or "phone-photo")[:255],
+            object_key=key,
+            byte_size=len(blob),
+            caption=None,
+            # Attribute to the operator who opened the session — the phone
+            # holder is anonymous, and this keeps the audit trail meaningful.
+            uploaded_by=session.created_by,
+        )
+        db.add(row)
+        session.upload_count += 1
+        db.commit()
+        return {"ok": True, "purpose": session.purpose}
+
+    # rubber_stamp relay: park the latest photo, replacing any prior one.
+    old_key = session.relay_object_key
+    key = object_key("capture/relay", _MIME_EXT[mime])
+    await run_in_threadpool(put_bytes, key, blob, mime)
+    session.relay_object_key = key
+    session.relay_mime = mime
+    session.relay_uploaded_at = datetime.now(timezone.utc)
+    session.upload_count += 1
+    db.commit()
+    if old_key:
+        delete_object(old_key)
+    return {"ok": True, "purpose": session.purpose}

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -768,3 +768,48 @@ class QueueEntryOut(BaseModel):
     bookedAt: Optional[datetime] = Field(default=None, validation_alias="booked_at")
     cancelledAt: Optional[datetime] = Field(default=None, validation_alias="cancelled_at")
     cancellationReason: Optional[str] = Field(default=None, validation_alias="cancellation_reason")
+
+
+# ── Capture sessions (phone-as-camera via QR) ─────────────────────────
+
+class CaptureSessionCreateIn(BaseModel):
+    """Desktop → server: mint a capture session.
+
+    `appointmentId` is required when purpose is appointment_attachment
+    (that's where the phone's photos land) and ignored otherwise. The
+    server re-validates the appointment exists and is writeable.
+    """
+    purpose: Literal["appointment_attachment", "rubber_stamp"]
+    appointmentId: Optional[int] = None
+
+
+class CaptureSessionOut(BaseModel):
+    """Creation response. `token` is the raw secret — returned exactly once
+    here so the desktop can build the QR; never re-fetchable afterwards."""
+    id: int
+    token: str
+    purpose: str
+    expiresAt: datetime = Field(validation_alias="expires_at")
+
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+
+class CaptureSessionStatusOut(BaseModel):
+    """Desktop poll response — never carries the token. `relayReady` flags
+    that a rubber_stamp photo is parked and waiting to be pulled."""
+    model_config = ConfigDict(from_attributes=True, populate_by_name=True)
+
+    id: int
+    purpose: str
+    expiresAt: datetime = Field(validation_alias="expires_at")
+    closed: bool
+    uploadCount: int = Field(validation_alias="upload_count")
+    relayReady: bool
+
+
+class CapturePeekOut(BaseModel):
+    """Phone → server peek: just enough for the capture page to render the
+    right UI. No appointment/patient detail — the scanner is unauthenticated
+    beyond holding the token, so we leak nothing identifying."""
+    purpose: str
+    expiresAt: datetime

--- a/backend/app/services/capture.py
+++ b/backend/app/services/capture.py
@@ -1,0 +1,113 @@
+"""Mint, look up, and tear down phone-camera capture sessions.
+
+A capture session is a short-lived, single-purpose credential that lets
+any phone act as a one-shot camera for the logged-in operator at the
+desk. The operator mints one (the desktop calls create_session), gets a
+raw token back, and renders a QR code encoding
+
+    {origin}/capture/{raw_token}
+
+The phone that scans it lands on a public page and uploads photos to the
+token-authenticated endpoints in routers/capture.py — the photo bytes go
+phone → server and never touch the operator's computer.
+
+Token format mirrors doctor_invites / setup_tokens: secrets.token_urlsafe
+(32) → ~43 chars of URL-safe entropy. We store only sha256-hex of it; the
+raw value is shown once (inside the QR) and never persisted, so a database
+leak can't reconstruct a scannable link.
+
+Liveness: `closed_at IS NULL AND expires_at > NOW()`. There's no
+single-use consume step — a session can take several photos until the
+operator closes it or it lapses on the short TTL.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from ..errors import not_found
+from ..models import CaptureSession
+
+
+# How long a QR stays scannable. Deliberately short: the operator is
+# standing next to the patient when they mint it, so a few minutes is
+# ample, and a leaked link shouldn't sit usable for long.
+CAPTURE_TTL_MINUTES = 15
+
+# What the phone is allowed to do with an upload. Kept in sync with the
+# `purpose` Literal on CaptureSessionCreateIn.
+VALID_PURPOSES = ("appointment_attachment", "rubber_stamp")
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def create_session(
+    db: Session,
+    *,
+    purpose: str,
+    created_by: str,
+    appointment_id: int | None = None,
+) -> tuple[CaptureSession, str]:
+    """Mint a session row and return (row, raw_token).
+
+    The raw token is what goes into the QR; only its hash is stored. The
+    caller is responsible for validating `purpose`/`appointment_id`
+    consistency (e.g. an appointment must exist and be writeable) before
+    calling here — this layer just persists.
+    """
+    raw = secrets.token_urlsafe(32)
+    now = datetime.now(timezone.utc)
+    row = CaptureSession(
+        token_hash=_hash(raw),
+        purpose=purpose,
+        appointment_id=appointment_id,
+        created_by=created_by,
+        expires_at=now + timedelta(minutes=CAPTURE_TTL_MINUTES),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return row, raw
+
+
+def lookup_live(db: Session, *, raw_token: str) -> CaptureSession:
+    """Resolve a raw token to its live CaptureSession.
+
+    Raises 404 `capture_session_not_found` for unknown / closed / expired
+    tokens, without distinguishing between them — a scanner shouldn't be
+    able to probe which state a given token is in.
+    """
+    row = db.scalar(
+        select(CaptureSession).where(CaptureSession.token_hash == _hash(raw_token))
+    )
+    now = datetime.now(timezone.utc)
+    if row is None or row.closed_at is not None or row.expires_at <= now:
+        raise not_found("capture_session_not_found")
+    return row
+
+
+def get_owned(db: Session, *, session_id: int, username: str) -> CaptureSession:
+    """Fetch a session the caller owns, for desktop-side status/close/pull.
+
+    Scoped to `created_by` so one operator can't poll or tear down another
+    operator's session. Unknown id or wrong owner both surface as 404 so
+    the id space isn't enumerable.
+    """
+    row = db.get(CaptureSession, session_id)
+    if row is None or row.created_by != username:
+        raise not_found("capture_session_not_found")
+    return row
+
+
+def close(db: Session, session: CaptureSession) -> None:
+    """Mark a session closed (idempotent). Called when the desktop modal is
+    dismissed so the QR stops working immediately rather than at TTL."""
+    if session.closed_at is None:
+        session.closed_at = datetime.now(timezone.utc)
+        db.commit()

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "lucide-react": "0.460.0",
         "luxon": "^3.7.2",
         "next": "15.5.18",
+        "qrcode.react": "^4.2.0",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "react-hook-form": "7.53.2",
@@ -5495,6 +5496,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qrcode.react": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/qrcode.react/-/qrcode.react-4.2.0.tgz",
+      "integrity": "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/queue-microtask": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "lucide-react": "0.460.0",
     "luxon": "^3.7.2",
     "next": "15.5.18",
+    "qrcode.react": "^4.2.0",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "react-hook-form": "7.53.2",

--- a/frontend/src/app/capture/[token]/page.tsx
+++ b/frontend/src/app/capture/[token]/page.tsx
@@ -299,7 +299,12 @@ export default function CapturePage() {
         <div className="flex items-center justify-center gap-3">
           {shot ? (
             <>
-              <Button variant="secondary" onClick={retake} disabled={uploading}>
+              <Button
+                variant="secondary"
+                onClick={retake}
+                disabled={uploading}
+                className="border-white/30 text-white hover:border-white/50 hover:bg-white/10 hover:text-white"
+              >
                 <RefreshCw className="h-4 w-4" />
                 Retake
               </Button>
@@ -316,6 +321,7 @@ export default function CapturePage() {
                   size="icon"
                   onClick={() => setFacing((f) => (f === "environment" ? "user" : "environment"))}
                   aria-label="Switch camera"
+                  className="border-white/30 text-white hover:border-white/50 hover:bg-white/10 hover:text-white"
                 >
                   <SwitchCamera className="h-4 w-4" />
                 </Button>

--- a/frontend/src/app/capture/[token]/page.tsx
+++ b/frontend/src/app/capture/[token]/page.tsx
@@ -1,0 +1,341 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useParams } from "next/navigation";
+import { Camera, Check, RefreshCw, SwitchCamera } from "lucide-react";
+
+import { Button } from "@/components/primitives/button";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { API_URL, ApiError, api } from "@/lib/api";
+import { explainError } from "@/lib/error-codes";
+
+// Public, token-authenticated "your phone is now a camera" page. Reached by
+// scanning the QR a desktop operator shows; the {token} in the path is the
+// only credential. No login, no cookies — the page peeks the token, drives
+// the phone camera, and POSTs each JPEG straight back to the server.
+//
+// Purpose-aware copy:
+//   appointment_attachment → many photos; stays open so they can keep
+//       snapping ("Take another").
+//   rubber_stamp → one photo is enough; after it sends we nudge them back
+//       to the computer where it appears in the editor.
+
+type PageState =
+  | { mode: "loading" }
+  | { mode: "invalid"; reason: string }
+  | { mode: "ready"; purpose: string }
+  | { mode: "sent"; purpose: string };
+
+const MAX_DIMENSION = 1920;
+const JPEG_QUALITY = 0.92;
+
+export default function CapturePage() {
+  const params = useParams<{ token: string }>();
+  const token = Array.isArray(params.token) ? params.token[0] : params.token;
+
+  const [state, setState] = useState<PageState>({ mode: "loading" });
+  const [error, setError] = useState<string | null>(null);
+  const [shot, setShot] = useState<string | null>(null);
+  const [ready, setReady] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [facing, setFacing] = useState<"environment" | "user">("environment");
+  const [canSwitch, setCanSwitch] = useState(false);
+
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const fileRef = useRef<File | null>(null);
+  const objectUrlRef = useRef<string | null>(null);
+
+  const setShotUrl = (url: string | null) => {
+    if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+    objectUrlRef.current = url;
+    setShot(url);
+  };
+
+  // Validate the token once on mount.
+  useEffect(() => {
+    if (!token) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const peek = await api<{ purpose: string; expiresAt: string }>(
+          `/capture/${token}`,
+          { skipAuthRedirect: true },
+        );
+        if (!cancelled) setState({ mode: "ready", purpose: peek.purpose });
+      } catch (err) {
+        if (cancelled) return;
+        if (err instanceof ApiError && (err.status === 404 || err.status === 409)) {
+          setState({ mode: "invalid", reason: explainError(err.error) });
+        } else {
+          setState({
+            mode: "invalid",
+            reason: "Couldn't reach the server. Try scanning again in a moment.",
+          });
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // Run the camera while we're on a capture screen (ready, no shot yet).
+  const cameraActive = (state.mode === "ready" || state.mode === "sent") && !shot;
+  useEffect(() => {
+    if (!cameraActive) return;
+    let cancelled = false;
+    setError(null);
+    setReady(false);
+
+    (async () => {
+      if (!navigator.mediaDevices?.getUserMedia) {
+        setError("This phone or browser doesn't support camera access.");
+        return;
+      }
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: { facingMode: facing },
+          audio: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (videoRef.current) {
+          videoRef.current.srcObject = stream;
+          await videoRef.current.play().catch(() => {});
+        }
+        setReady(true);
+        navigator.mediaDevices
+          .enumerateDevices()
+          .then((ds) => {
+            if (!cancelled) {
+              setCanSwitch(ds.filter((d) => d.kind === "videoinput").length > 1);
+            }
+          })
+          .catch(() => {});
+      } catch (err) {
+        if (cancelled) return;
+        setError(
+          err instanceof DOMException && err.name === "NotAllowedError"
+            ? "Camera access was blocked. Allow camera permission and reload."
+            : "Couldn't start the camera. Close other camera apps and try again.",
+        );
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, [cameraActive, facing]);
+
+  // Clean up on unmount.
+  useEffect(
+    () => () => {
+      if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
+      streamRef.current?.getTracks().forEach((t) => t.stop());
+    },
+    [],
+  );
+
+  const capture = () => {
+    const video = videoRef.current;
+    if (!video || !video.videoWidth || !video.videoHeight) return;
+    const { videoWidth: vw, videoHeight: vh } = video;
+    const scale = Math.min(1, MAX_DIMENSION / Math.max(vw, vh));
+    const cw = Math.round(vw * scale);
+    const ch = Math.round(vh * scale);
+    const canvas = document.createElement("canvas");
+    canvas.width = cw;
+    canvas.height = ch;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0, cw, ch);
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          setError("Couldn't capture the photo. Try again.");
+          return;
+        }
+        fileRef.current = new File([blob], `phone-${Date.now()}.jpg`, {
+          type: "image/jpeg",
+        });
+        setShotUrl(URL.createObjectURL(blob));
+      },
+      "image/jpeg",
+      JPEG_QUALITY,
+    );
+  };
+
+  const retake = () => {
+    setShotUrl(null);
+    fileRef.current = null;
+  };
+
+  const send = async () => {
+    if (!fileRef.current || !token) return;
+    setUploading(true);
+    setError(null);
+    try {
+      const form = new FormData();
+      form.append("file", fileRef.current);
+      const res = await fetch(`${API_URL}/capture/${token}`, {
+        method: "POST",
+        body: form,
+      });
+      if (!res.ok) {
+        let code = "request_failed";
+        try {
+          const body = await res.json();
+          const inner = body?.detail ?? body;
+          if (inner && typeof inner === "object" && "error" in inner) {
+            code = String((inner as { error: string }).error);
+          }
+        } catch {
+          /* keep default */
+        }
+        setError(explainError(code));
+        setUploading(false);
+        return;
+      }
+      const purpose = state.mode === "ready" ? state.purpose : "appointment_attachment";
+      setShotUrl(null);
+      fileRef.current = null;
+      setState({ mode: "sent", purpose });
+    } catch {
+      setError("Upload failed. Check your connection and try again.");
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const takeAnother = () => {
+    if (state.mode === "sent") setState({ mode: "ready", purpose: state.purpose });
+  };
+
+  // ── Render ──────────────────────────────────────────────────────────
+
+  if (state.mode === "loading") {
+    return (
+      <Centered>
+        <p className="text-sm text-white/70">Checking the link…</p>
+      </Centered>
+    );
+  }
+
+  if (state.mode === "invalid") {
+    return (
+      <Centered>
+        <div className="w-full max-w-sm rounded-2xl bg-white p-6 text-center shadow-xl">
+          <h1 className="text-lg font-semibold">Link not active</h1>
+          <p className="mt-2 text-sm text-[var(--muted-foreground)]">{state.reason}</p>
+          <p className="mt-4 text-xs text-[var(--muted-foreground)]">
+            Ask the person at the computer to show a fresh QR code, then scan again.
+          </p>
+        </div>
+      </Centered>
+    );
+  }
+
+  const isStamp =
+    (state.mode === "ready" || state.mode === "sent") && state.purpose === "rubber_stamp";
+
+  if (state.mode === "sent") {
+    return (
+      <Centered>
+        <div className="w-full max-w-sm rounded-2xl bg-white p-6 text-center shadow-xl">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-emerald-100 text-emerald-600">
+            <Check className="h-6 w-6" />
+          </div>
+          <h1 className="mt-3 text-lg font-semibold">Photo sent</h1>
+          <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+            {isStamp
+              ? "It's on its way to the computer — you can put the phone down now."
+              : "It's now on the computer. Take more if you need to."}
+          </p>
+          {!isStamp && (
+            <Button className="mt-5 w-full" onClick={takeAnother}>
+              <Camera className="h-4 w-4" />
+              Take another photo
+            </Button>
+          )}
+        </div>
+      </Centered>
+    );
+  }
+
+  // mode === "ready"
+  return (
+    <div className="flex min-h-[100dvh] flex-col bg-black">
+      <div className="px-4 pt-[max(1rem,env(safe-area-inset-top))] pb-2 text-center text-sm text-white/80">
+        {isStamp ? "Take a clear photo of the rubber stamp" : "Take a photo for the doctor"}
+      </div>
+
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden">
+        {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+        <video
+          ref={videoRef}
+          playsInline
+          muted
+          className={"h-full w-full object-contain " + (shot ? "hidden" : "block")}
+        />
+        {shot && (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img src={shot} alt="Captured" className="h-full w-full object-contain" />
+        )}
+        {!ready && !shot && !error && (
+          <div className="absolute inset-0 flex items-center justify-center text-sm text-white/70">
+            Starting camera…
+          </div>
+        )}
+      </div>
+
+      <div className="flex flex-col gap-3 px-4 pb-[max(1.25rem,env(safe-area-inset-bottom))] pt-3">
+        {error && <ErrorBanner>{error}</ErrorBanner>}
+        <div className="flex items-center justify-center gap-3">
+          {shot ? (
+            <>
+              <Button variant="secondary" onClick={retake} disabled={uploading}>
+                <RefreshCw className="h-4 w-4" />
+                Retake
+              </Button>
+              <Button onClick={send} disabled={uploading}>
+                <Check className="h-4 w-4" />
+                {uploading ? "Sending…" : "Send photo"}
+              </Button>
+            </>
+          ) : (
+            <>
+              {canSwitch && (
+                <Button
+                  variant="secondary"
+                  size="icon"
+                  onClick={() => setFacing((f) => (f === "environment" ? "user" : "environment"))}
+                  aria-label="Switch camera"
+                >
+                  <SwitchCamera className="h-4 w-4" />
+                </Button>
+              )}
+              <Button size="lg" onClick={capture} disabled={!ready}>
+                <Camera className="h-5 w-5" />
+                Capture
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Centered({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex min-h-[100dvh] items-center justify-center bg-[var(--foreground)] p-6">
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -326,7 +326,13 @@ export function DoctorForm({
       </Section>
 
       <Section Icon={Stamp} title="Rubber stamp" hint={isCreate ? "Required (§1.7)." : "Replace only if you need to update the existing stamp."}>
-        <RubberStampUploader value={stamp} onChange={handleStampChange} />
+        {/* Phone-camera QR needs an authenticated admin to mint a session,
+            so it's only offered outside the public self-onboarding form. */}
+        <RubberStampUploader
+          value={stamp}
+          onChange={handleStampChange}
+          enableQrCapture={!isSelfOnboarding}
+        />
         {stampError && <p className="mt-2 text-xs text-rose-600">{stampError}</p>}
       </Section>
 

--- a/frontend/src/components/admin/rubber-stamp-uploader.tsx
+++ b/frontend/src/components/admin/rubber-stamp-uploader.tsx
@@ -1,12 +1,13 @@
 "use client";
 
-import { Camera, Pencil, Stamp, Upload, X } from "lucide-react";
+import { Camera, Pencil, Smartphone, Stamp, Upload, X } from "lucide-react";
 import { useRef, useState, type ChangeEvent } from "react";
 
 import { Button } from "@/components/primitives/button";
 import { CameraCaptureModal } from "@/components/primitives/camera-capture-modal";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { Modal } from "@/components/primitives/modal";
+import { QrCaptureModal } from "@/components/primitives/qr-capture-modal";
 import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
 
 const MAX_BYTES = 1_000_000; // 1 MB — keeps the patient PDF lean
@@ -14,18 +15,26 @@ const ACCEPTED = ["image/png", "image/jpeg"];
 
 // Reads a file → base64 data URL (`data:image/png;base64,…`). The backend
 // strips the data: prefix on its own, so either form is acceptable.
+//
+// `enableQrCapture` adds a "Use phone" option that mints a capture session
+// and relays a phone photo into the editor. It's off by default because
+// minting a session needs an authenticated admin — the public doctor
+// self-onboarding form renders this same component without it.
 export function RubberStampUploader({
   value,
   onChange,
+  enableQrCapture = false,
 }: {
   value: string | null;
   onChange: (next: string | null) => void;
+  enableQrCapture?: boolean;
 }) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [error, setError] = useState<string | null>(null);
   const [previewOpen, setPreviewOpen] = useState(false);
   const [editorSource, setEditorSource] = useState<string | null>(null);
   const [cameraOpen, setCameraOpen] = useState(false);
+  const [qrOpen, setQrOpen] = useState(false);
 
   // Validate then read a file → base64 data URL → open the editor. Shared by
   // the file picker and the camera capture.
@@ -105,6 +114,17 @@ export function RubberStampUploader({
               <Camera className="h-3.5 w-3.5" />
               Take photo
             </Button>
+            {enableQrCapture && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setQrOpen(true)}
+              >
+                <Smartphone className="h-3.5 w-3.5" />
+                Use phone
+              </Button>
+            )}
             <Button
               type="button"
               variant="ghost"
@@ -133,16 +153,28 @@ export function RubberStampUploader({
               </div>
             </div>
           </button>
-          <Button
-            type="button"
-            variant="secondary"
-            size="sm"
-            className="self-center"
-            onClick={() => setCameraOpen(true)}
-          >
-            <Camera className="h-3.5 w-3.5" />
-            Take a photo instead
-          </Button>
+          <div className="flex flex-wrap items-center justify-center gap-2">
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              onClick={() => setCameraOpen(true)}
+            >
+              <Camera className="h-3.5 w-3.5" />
+              Take a photo instead
+            </Button>
+            {enableQrCapture && (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => setQrOpen(true)}
+              >
+                <Smartphone className="h-3.5 w-3.5" />
+                Use phone camera
+              </Button>
+            )}
+          </div>
         </div>
       )}
       <input
@@ -197,6 +229,16 @@ export function RubberStampUploader({
         quality={0.9}
         filename="rubber-stamp.jpg"
       />
+
+      {enableQrCapture && (
+        <QrCaptureModal
+          open={qrOpen}
+          onClose={() => setQrOpen(false)}
+          purpose="rubber_stamp"
+          onRelayReceived={processFile}
+          title="Photograph the stamp with a phone"
+        />
+      )}
     </div>
   );
 }

--- a/frontend/src/components/healthworker/attachments-panel.tsx
+++ b/frontend/src/components/healthworker/attachments-panel.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { useRef, useState } from "react";
-import { Camera, Trash2, Upload } from "lucide-react";
+import { Camera, Smartphone, Trash2, Upload } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
 import { CameraCaptureModal } from "@/components/primitives/camera-capture-modal";
 import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { ImagePreviewModal } from "@/components/primitives/image-preview-modal";
+import { QrCaptureModal } from "@/components/primitives/qr-capture-modal";
 import { ApiError } from "@/lib/api";
 import { explainError } from "@/lib/error-codes";
 import {
@@ -33,6 +34,7 @@ export function AttachmentsPanel({
   const upload = useUploadAttachment(appointmentId);
   const [uploadError, setUploadError] = useState<string | null>(null);
   const [cameraOpen, setCameraOpen] = useState(false);
+  const [qrOpen, setQrOpen] = useState(false);
 
   const readonly = READONLY_STATES.includes(status);
 
@@ -84,6 +86,15 @@ export function AttachmentsPanel({
               Take photo
             </Button>
             <Button
+              variant="secondary"
+              onClick={() => setQrOpen(true)}
+              disabled={upload.isPending}
+              size="sm"
+            >
+              <Smartphone className="h-3.5 w-3.5" />
+              Use phone
+            </Button>
+            <Button
               onClick={() => fileInput.current?.click()}
               disabled={upload.isPending}
               size="sm"
@@ -128,6 +139,14 @@ export function AttachmentsPanel({
         onClose={() => setCameraOpen(false)}
         onCapture={(file) => uploadFiles([file])}
         filename={`photo-${Date.now()}.jpg`}
+      />
+
+      <QrCaptureModal
+        open={qrOpen}
+        onClose={() => setQrOpen(false)}
+        purpose="appointment_attachment"
+        appointmentId={appointmentId}
+        title="Snap photos from a phone"
       />
     </Card>
   );

--- a/frontend/src/components/primitives/qr-capture-modal.tsx
+++ b/frontend/src/components/primitives/qr-capture-modal.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { AnimatePresence, motion } from "framer-motion";
+import { Check, RefreshCw, Smartphone, X } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { QRCodeSVG } from "qrcode.react";
+import { useQueryClient } from "@tanstack/react-query";
+
+import { Button } from "@/components/primitives/button";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { API_URL, type ApiError, readCookie } from "@/lib/api";
+import { explainError } from "@/lib/error-codes";
+import { useCaptureSessionStatus, useCreateCaptureSession } from "@/lib/use-api";
+import type { CapturePurpose } from "@/types/api";
+
+const CSRF_HEADER_NAME = "X-CSRF-Token";
+
+// "Scan to use your phone as a camera" popup. Mints a capture session,
+// renders the QR a phone scans, and watches the session until photos come
+// back. Two behaviours by purpose:
+//
+//   appointment_attachment → photos land straight on the appointment; we
+//       refresh the attachments grid behind the modal as they arrive and
+//       show a running count. The operator clicks Done when finished.
+//   rubber_stamp → the phone parks one photo server-side; as soon as it
+//       arrives we pull the bytes, hand them to onRelayReceived (the stamp
+//       editor), and close.
+//
+// The bytes go phone → server directly; for attachments they never touch
+// this computer at all.
+export function QrCaptureModal({
+  open,
+  onClose,
+  purpose,
+  appointmentId,
+  onRelayReceived,
+  title,
+}: {
+  open: boolean;
+  onClose: () => void;
+  purpose: CapturePurpose;
+  appointmentId?: number;
+  // Required for the rubber_stamp purpose — receives the pulled photo.
+  onRelayReceived?: (file: File) => void;
+  title?: string;
+}) {
+  const qc = useQueryClient();
+  const create = useCreateCaptureSession();
+
+  const [session, setSession] = useState<
+    { id: number; token: string; expiresAt: string } | null
+  >(null);
+  const [error, setError] = useState<string | null>(null);
+  const [relayDone, setRelayDone] = useState(false);
+
+  // Guards: avoid double-pulling the relay photo, and remember the last
+  // upload count so we only refresh the grid when it actually grows.
+  const relayHandledRef = useRef(false);
+  const lastCountRef = useRef(0);
+
+  // Fire-and-forget close so the QR stops working the moment we're done.
+  const closeSession = (id: number) => {
+    const csrf = readCookie("csrf_token");
+    fetch(`${API_URL}/capture/sessions/${id}`, {
+      method: "DELETE",
+      credentials: "include",
+      headers: csrf ? { [CSRF_HEADER_NAME]: csrf } : {},
+      keepalive: true,
+    }).catch(() => {});
+  };
+
+  // Mint a session whenever the modal opens; tear it down on close/unmount.
+  useEffect(() => {
+    if (!open) return;
+    let active = true;
+    let createdId: number | null = null;
+    setError(null);
+    setRelayDone(false);
+    relayHandledRef.current = false;
+    lastCountRef.current = 0;
+    setSession(null);
+
+    (async () => {
+      try {
+        const s = await create.mutateAsync({ purpose, appointmentId });
+        if (!active) {
+          closeSession(s.id);
+          return;
+        }
+        createdId = s.id;
+        setSession({ id: s.id, token: s.token, expiresAt: s.expiresAt });
+      } catch (e) {
+        if (active) setError(explainError((e as ApiError).error));
+      }
+    })();
+
+    return () => {
+      active = false;
+      if (createdId != null) closeSession(createdId);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const status = useCaptureSessionStatus(session?.id ?? null, {
+    enabled: open && !!session && !relayDone,
+  });
+  const expired = status.data?.closed ?? false;
+  const uploadCount = status.data?.uploadCount ?? 0;
+
+  // React to the polled status: refresh the grid for attachments, or pull
+  // the parked photo for the stamp relay.
+  useEffect(() => {
+    const data = status.data;
+    if (!data || data.closed) return;
+
+    if (purpose === "appointment_attachment") {
+      if (data.uploadCount > lastCountRef.current) {
+        lastCountRef.current = data.uploadCount;
+        if (appointmentId != null) {
+          qc.invalidateQueries({ queryKey: ["appointments", appointmentId, "attachments"] });
+          qc.invalidateQueries({ queryKey: ["appointments", appointmentId] });
+        }
+      }
+      return;
+    }
+
+    // rubber_stamp
+    if (data.relayReady && !relayHandledRef.current) {
+      relayHandledRef.current = true;
+      (async () => {
+        try {
+          const res = await fetch(`${API_URL}/capture/sessions/${data.id}/relay`, {
+            credentials: "include",
+          });
+          if (!res.ok) {
+            relayHandledRef.current = false;
+            return;
+          }
+          const blob = await res.blob();
+          const type = blob.type || "image/jpeg";
+          const ext = type.includes("png") ? "png" : "jpg";
+          onRelayReceived?.(new File([blob], `phone-stamp.${ext}`, { type }));
+          setRelayDone(true);
+          onClose();
+        } catch {
+          relayHandledRef.current = false;
+        }
+      })();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status.data?.uploadCount, status.data?.relayReady, status.data?.closed]);
+
+  const regenerate = () => {
+    if (session) closeSession(session.id);
+    setSession(null);
+    setError(null);
+    relayHandledRef.current = false;
+    lastCountRef.current = 0;
+    (async () => {
+      try {
+        const s = await create.mutateAsync({ purpose, appointmentId });
+        setSession({ id: s.id, token: s.token, expiresAt: s.expiresAt });
+      } catch (e) {
+        setError(explainError((e as ApiError).error));
+      }
+    })();
+  };
+
+  const captureUrl =
+    session && typeof window !== "undefined"
+      ? `${window.location.origin}/capture/${session.token}`
+      : null;
+
+  const heading = title ?? "Use your phone as a camera";
+
+  return (
+    <AnimatePresence>
+      {open && (
+        <motion.div
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.18 }}
+          className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
+          onClick={onClose}
+          role="dialog"
+          aria-modal
+        >
+          <motion.div
+            initial={{ opacity: 0, y: 12, scale: 0.97 }}
+            animate={{ opacity: 1, y: 0, scale: 1 }}
+            exit={{ opacity: 0, y: 8, scale: 0.97 }}
+            transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
+            onClick={(e) => e.stopPropagation()}
+            className="flex max-h-full w-full max-w-md flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
+          >
+            <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">
+              <span className="flex items-center gap-2 text-sm font-medium text-[var(--foreground)]">
+                <Smartphone className="h-4 w-4 text-[var(--accent)]" />
+                {heading}
+              </span>
+              <Button variant="ghost" size="icon" onClick={onClose} aria-label="Close">
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="flex flex-col items-center gap-4 p-6">
+              {error ? (
+                <div className="flex w-full flex-col gap-3">
+                  <ErrorBanner>{error}</ErrorBanner>
+                  <Button variant="secondary" onClick={regenerate}>
+                    <RefreshCw className="h-4 w-4" />
+                    Try again
+                  </Button>
+                </div>
+              ) : !captureUrl ? (
+                <div className="flex h-[232px] items-center justify-center text-sm text-[var(--muted-foreground)]">
+                  Generating code…
+                </div>
+              ) : (
+                <>
+                  <p className="text-center text-sm text-[var(--muted-foreground)]">
+                    Scan this with any phone&rsquo;s camera. It opens a page that
+                    takes the photo and sends it here — nothing is saved on the
+                    phone or this computer.
+                  </p>
+
+                  <div className="relative rounded-xl border border-[var(--border)] bg-white p-4">
+                    <QRCodeSVG value={captureUrl} size={196} level="M" />
+                    {expired && (
+                      <div className="absolute inset-0 flex flex-col items-center justify-center gap-2 rounded-xl bg-[var(--card)]/90 backdrop-blur-sm">
+                        <span className="text-sm font-medium">This code expired</span>
+                        <Button size="sm" onClick={regenerate}>
+                          <RefreshCw className="h-3.5 w-3.5" />
+                          New code
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+
+                  {purpose === "appointment_attachment" ? (
+                    <div className="flex w-full flex-col items-center gap-3">
+                      <div className="flex items-center gap-2 text-sm">
+                        {uploadCount > 0 ? (
+                          <span className="inline-flex items-center gap-1.5 font-medium text-emerald-600">
+                            <Check className="h-4 w-4" />
+                            {uploadCount} photo{uploadCount === 1 ? "" : "s"} received
+                          </span>
+                        ) : (
+                          <span className="text-[var(--muted-foreground)]">
+                            Waiting for the first photo…
+                          </span>
+                        )}
+                      </div>
+                      <Button className="w-full" onClick={onClose}>
+                        Done
+                      </Button>
+                    </div>
+                  ) : (
+                    <p className="text-center text-sm text-[var(--muted-foreground)]">
+                      Waiting for the photo… it&rsquo;ll drop into the editor
+                      automatically.
+                    </p>
+                  )}
+                </>
+              )}
+            </div>
+          </motion.div>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -20,6 +20,10 @@ const MESSAGES: Record<string, string> = {
   attachment_empty: "That file appeared to be empty.",
   attachment_unsupported_type: "Only JPEG, PNG, and WebP images can be attached.",
   attachment_not_found: "That attachment couldn't be found.",
+  // Phone-camera capture (QR)
+  capture_session_not_found: "This capture link is no longer active — generate a fresh QR code.",
+  capture_relay_empty: "No photo has been received from the phone yet.",
+  appointment_required: "An appointment is required to start a phone capture.",
   patient_not_found: "Patient not found.",
   doctor_not_found: "Doctor not found.",
   appointment_not_found: "Appointment not found.",

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -18,6 +18,9 @@ import type {
   AvailabilityCreateRequest,
   AvailabilityUpdateRequest,
   CalendarAppointment,
+  CapturePurpose,
+  CaptureSession,
+  CaptureSessionStatus,
   Consent,
   Consultation,
   CreateOperatingAccountRequest,
@@ -875,6 +878,41 @@ export function useCreateOperatingAccount() {
         method: "POST",
         body,
       }),
+  });
+}
+
+// ── Capture sessions (phone-as-camera via QR) ────────────────────────
+
+// Mint a capture session. The response carries the raw token (shown once,
+// inside the QR) so the desktop can build the scannable link.
+export function useCreateCaptureSession() {
+  const fetcher = useAuthedApi();
+  return useMutation<
+    CaptureSession,
+    ApiError,
+    { purpose: CapturePurpose; appointmentId?: number }
+  >({
+    mutationFn: (body) =>
+      fetcher<CaptureSession>("/capture/sessions", { method: "POST", body }),
+  });
+}
+
+// Poll a capture session's status while the QR modal is open. `intervalMs`
+// drives the refetch cadence; pass enabled=false to stop polling (e.g. once
+// the modal closes or the session lapses).
+export function useCaptureSessionStatus(
+  sessionId: number | null,
+  { enabled = true, intervalMs = 2500 }: { enabled?: boolean; intervalMs?: number } = {},
+) {
+  const fetcher = useAuthedApi();
+  return useQuery<CaptureSessionStatus, ApiError>({
+    queryKey: ["capture", "session", sessionId],
+    queryFn: () => fetcher<CaptureSessionStatus>(`/capture/sessions/${sessionId}`),
+    enabled: enabled && sessionId != null,
+    refetchInterval: enabled ? intervalMs : false,
+    // Status is inherently live — never serve a stale cached value.
+    staleTime: 0,
+    gcTime: 0,
   });
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -249,6 +249,25 @@ export type AttachmentMeta = {
   uploadedAt: string;
 };
 
+// ── Capture sessions (phone-as-camera via QR) ────────────────────────
+export type CapturePurpose = "appointment_attachment" | "rubber_stamp";
+
+export type CaptureSession = {
+  id: number;
+  token: string; // raw secret — only present in the creation response
+  purpose: CapturePurpose;
+  expiresAt: string;
+};
+
+export type CaptureSessionStatus = {
+  id: number;
+  purpose: CapturePurpose;
+  expiresAt: string;
+  closed: boolean;
+  uploadCount: number;
+  relayReady: boolean;
+};
+
 export type AppointmentDetail = {
   appointment: Appointment;
   patient: Patient | null;


### PR DESCRIPTION
## What

Adds an **additional capture option** alongside file upload and the computer webcam: a desktop **"Use phone"** button shows a QR code; any phone scans it, opens a public camera page, and the photo goes **phone → server directly** — it never has to arrive on the operator's computer.

One generic, server-finalized mechanism powers two spots:

- **Pre-consultation photos** (health-worker attachments panel) → the photo is committed straight to the appointment as an attachment; the desktop grid just refreshes as photos land. Bytes never touch the desktop.
- **Doctor rubber stamp** (admin doctor form) → no destination record exists yet, so the photo is relayed into the stamp editor for cropping. Gated to the authenticated admin form (off in public self-onboarding, which can't mint a session).

## How it works

1. Logged-in operator mints a short-lived **capture session** (`POST /capture/sessions`) → gets a raw token.
2. Desktop renders a QR encoding `{origin}/capture/{token}` (`qrcode.react`).
3. Phone scans → public, token-authenticated page (`/capture/[token]`) drives `getUserMedia` and uploads via `POST /capture/{token}`.
4. Server routes the upload by the session's `purpose`; desktop polls status (`GET /capture/sessions/{id}`) and either refreshes the grid or pulls the relayed stamp photo.

Security mirrors the existing `doctor_invites` pattern: only the **sha256 hash** of the token is stored, **15-min TTL**, single owner-scoped session, and the public endpoints bypass session/CSRF because the unguessable token *is* the credential.

## Backend

- `capture_sessions` table + migration `0015_capture_sessions` (chained onto main's `0014` head).
- `services/capture.py` (mint / lookup-live / owner-scoped fetch / close).
- `routers/capture.py` — authed session create/status/relay/close + public peek/upload. Reuses the attachments router's MIME/size validation.

## Frontend

- `QrCaptureModal` primitive (mint → QR → poll → deliver), public `/capture/[token]` mobile camera page, and "Use phone" buttons wired into the attachments panel and rubber-stamp uploader. Adds `qrcode.react`.

## Verification

- ✅ `tsc --noEmit`, `next lint`, and full `next build` pass.
- ✅ Single alembic head (`0015_capture_sessions`); migrations apply cleanly `0011 → 0015`.
- ✅ Endpoint smoke test: bogus-token peek/upload → `404 capture_session_not_found`; unauthenticated `POST /capture/sessions` → `401`.
- ✅ End-to-end tested on a real phone over an HTTPS tunnel (photo capture → appears on desktop; stamp relay → editor).

## Notes for reviewers

- Camera capture requires a **secure context** (HTTPS) — works on the prod domain; local phone testing needs an HTTPS tunnel.
- The QR is built from `window.location.origin`, so desktop and phone must share the same reachable origin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)