### PR TITLE
ci(docker): bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,8 +38,8 @@ jobs:
       backend: ${{ steps.filter.outputs.backend }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
@@ -105,8 +105,8 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -141,8 +141,8 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -183,7 +183,7 @@ jobs:
             context: ./frontend
             image: ghcr.io/sight-hkust/haputele-frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
## What
GitHub is deprecating the Node.js 20 runtime for JavaScript actions: it will be **forced to Node 24 on 2026-06-16** and **removed entirely on 2026-09-16**. CI currently emits deprecation warnings from `docker.yml`.

Bump the four affected actions to versions that run on Node 24:

| Action | Before | After |
|---|---|---|
| `actions/checkout` (×4) | v4 | v5 |
| `dorny/paths-filter` | v3 | v4 |
| `actions/setup-python` | v5 | v6 |
| `actions/setup-node` | v4 | v5 |

`deploy.yml` was already on Node-24-era actions, so it's untouched.

## Notes
- These are runtime-only bumps; the action inputs we use are unchanged, so behavior is identical.
- The `frontend-checks` job still pins `node-version: "20"` — that's the Node the frontend builds with (app concern), unrelated to the runner deprecation, so it's intentionally left as-is.

## Verification
- ✅ YAML parses
- ✅ All four new tags confirmed to exist upstream (`git ls-remote`)
- ✅ `actionlint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)