### PR TITLE
feat(doctors): saved e-signature, self-service profile, optional institute phone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ scripts/assets/doctor_stamp.png
 # Archived documentation — kept locally, never committed.
 stale_documentation/
 
+
+# local worktree test env (not for commit)
+backend/.test-env.sh

--- a/backend/alembic/versions/0016_doctor_esignature_optional_institute.py
+++ b/backend/alembic/versions/0016_doctor_esignature_optional_institute.py
@@ -1,0 +1,38 @@
+"""doctor saved e-signature + optional institute contact
+
+Revision ID: 0016_doctor_esignature
+Revises: 0015_capture_sessions
+Create Date: 2026-06-09
+
+Two changes to the doctor table:
+
+  - default_signature_key → VARCHAR(512) NULL. S3 object key for the
+    doctor's optional saved e-signature. When present, consultations can be
+    finalised without drawing a signature; the bytes are copied into a fresh
+    per-consultation object at submit time, so a later change to this key
+    never alters a consultation that was already signed.
+  - institute_contact     → drop NOT NULL. The institute phone is now
+    optional at registration and on the self-service profile.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0016_doctor_esignature"
+down_revision: Union[str, None] = "0015_capture_sessions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE doctor ADD COLUMN IF NOT EXISTS default_signature_key VARCHAR(512)")
+    op.execute("ALTER TABLE doctor ALTER COLUMN institute_contact DROP NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE doctor DROP COLUMN IF EXISTS default_signature_key")
+    # NOT NULL is intentionally left relaxed on downgrade: rows inserted while
+    # this migration was applied may legitimately hold NULL institute_contact,
+    # and re-adding the constraint would fail against them. Re-tighten manually
+    # only after backfilling if a true rollback is ever required.

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -51,8 +51,16 @@ class Doctor(Base):
     qualifications: Mapped[str] = mapped_column(Text, nullable=False)
     practitioner_address: Mapped[str] = mapped_column(Text, nullable=False)
     institute_name: Mapped[str] = mapped_column(String(255), nullable=False)
-    institute_contact: Mapped[str] = mapped_column(String(255), nullable=False)
+    # Institute phone is optional — many practitioners list a clinic without a
+    # dedicated line, and §1.7 prescriptions remain valid without it.
+    institute_contact: Mapped[str | None] = mapped_column(String(255), nullable=True)
     rubber_stamp_key: Mapped[str] = mapped_column(String(512), nullable=False)
+    # Optional saved e-signature. When set, a doctor can finalise a
+    # consultation without drawing a signature each time — the bytes are
+    # copied into a fresh per-consultation object at submit so changing this
+    # later never mutates an already-signed consultation. Distinct from the
+    # rubber stamp (the official clinic stamp).
+    default_signature_key: Mapped[str | None] = mapped_column(String(512), nullable=True)
     active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
     # Approval workflow. Doctors self-onboard via an invite-by-email flow
     # which creates the row but leaves approved_at NULL; an admin reviews

--- a/backend/app/routers/consultations.py
+++ b/backend/app/routers/consultations.py
@@ -5,7 +5,7 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
-from ..errors import conflict, forbidden, not_found
+from ..errors import conflict, forbidden, not_found, unprocessable
 from ..dateutils import snap_to_monday
 from ..models import Appointment, Consultation, Doctor, QueueEntry
 from ..routers.appointments import _slot_taken
@@ -18,7 +18,7 @@ from ..schemas import (
     FollowUpWeeks,
 )
 from ..services.signature import decode_signature
-from ..services.storage import object_key, put_bytes
+from ..services.storage import get_bytes, object_key, put_bytes
 
 
 def _doctor(db: Session, user: CurrentUser) -> Doctor:
@@ -126,9 +126,18 @@ def submit_consultation(cid: int, payload: ConsultationSubmitIn, db: Session = D
     c, appt = _own_consultation(db, cid, user)
     if c.status != "draft":
         raise conflict("consultation_locked")
-    # decode_signature raises signature_required / invalid_signature_format /
-    # signature_too_large depending on what's wrong with the payload.
-    signature_bytes = decode_signature(payload.signature)
+    if payload.signature:
+        # decode_signature raises invalid_signature_format / signature_too_large
+        # depending on what's wrong with a supplied (drawn / one-off) signature.
+        signature_bytes = decode_signature(payload.signature)
+    else:
+        # No drawn signature — fall back to the doctor's saved default. We copy
+        # its bytes onto a fresh per-consultation object below, so a later
+        # change to the saved signature never mutates this signed consultation.
+        doctor = _doctor(db, user)
+        if not doctor.default_signature_key:
+            raise unprocessable("signature_required")
+        signature_bytes = get_bytes(doctor.default_signature_key)
     # Doctor may submit while the meeting is still live (in_progress) or after
     # the healthworker has ended it (awaiting_notes). The submit itself
     # finalizes the appointment; we don't make the doctor wait on the HW.

--- a/backend/app/routers/doctor_onboarding.py
+++ b/backend/app/routers/doctor_onboarding.py
@@ -33,7 +33,7 @@ from ..errors import unprocessable
 from ..models import Doctor
 from ..schemas import DoctorOnboardingPeek, DoctorOnboardingSubmit
 from ..services import doctor_invites as invites
-from ..services.signature import decode_rubber_stamp
+from ..services.signature import decode_rubber_stamp, decode_signature
 
 
 _logger = logging.getLogger("haputele.doctor_onboarding")
@@ -124,6 +124,17 @@ def complete(
     except Exception as exc:
         raise unprocessable("invalid_rubber_stamp_image", detail=str(exc))
 
+    # Optional saved e-signature — decoded here so a bad image fails the
+    # onboarding submit cleanly rather than deep in the service.
+    signature_bytes = (
+        decode_signature(submission.defaultSignatureImage)
+        if submission.defaultSignatureImage
+        else None
+    )
+
+    # Institute phone is optional; normalise blank/whitespace to None.
+    institute_contact = (submission.instituteContact or "").strip() or None
+
     doctor = invites.consume_new_doctor(
         db,
         raw_token=token,
@@ -137,9 +148,10 @@ def complete(
             "qualifications": submission.qualifications.strip(),
             "practitionerAddress": submission.practitionerAddress.strip(),
             "instituteName": submission.instituteName.strip(),
-            "instituteContact": submission.instituteContact.strip(),
+            "instituteContact": institute_contact,
         },
         rubber_stamp=stamp_bytes,
+        default_signature=signature_bytes,
     )
     _logger.info(
         "new doctor self-onboarded (awaiting approval): doctor_id=%s username=%s",

--- a/backend/app/routers/doctors.py
+++ b/backend/app/routers/doctors.py
@@ -18,13 +18,14 @@ from ..schemas import (
     DoctorInviteCreate,
     DoctorOut,
     DoctorRejectIn,
+    DoctorSelfUpdate,
     DoctorSummaryOut,
     DoctorUpdate,
 )
 from ..security import hash_password
 from ..services import doctor_invites as invites
 from ..services.email import is_configured as email_configured, send_templated
-from ..services.signature import decode_rubber_stamp
+from ..services.signature import decode_rubber_stamp, decode_signature
 from ..services.storage import delete_object, get_bytes, object_key, put_bytes
 
 
@@ -531,6 +532,113 @@ def doctor_summary(db: Session = Depends(db_dep)) -> DoctorSummaryOut:
         else:
             summary.active += 1
     return summary
+
+
+# ── Doctor self-service ───────────────────────────────────────────────
+# These literal "/me" routes MUST be declared before the "/{doctor_id}"
+# routes below, or FastAPI would match "me" as a (failing) int path param.
+
+def _current_doctor(db: Session, user: CurrentUser) -> Doctor:
+    doctor = db.scalar(select(Doctor).where(Doctor.username == user.username))
+    if doctor is None:
+        raise not_found("doctor_not_found")
+    return doctor
+
+
+def _self_out(db: Session, doctor: Doctor) -> DoctorOut:
+    out = DoctorOut.model_validate(doctor)
+    has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
+    return _attach_status(out, doctor, has_live_invite=has_live)
+
+
+@router.get("/me", response_model=DoctorOut)
+def get_me(
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(require_role("doctor")),
+) -> DoctorOut:
+    """The calling doctor's own profile, resolved from their session."""
+    return _self_out(db, _current_doctor(db, user))
+
+
+# Self-editable practice-profile text fields → ORM columns. Identity and
+# credential fields (name, email, SLMC) are deliberately absent: a doctor
+# can't change those themselves — that stays on the admin PATCH /{id}.
+_SELF_TEXT_FIELDS = {
+    "contact": "contact",
+    "qualifications": "qualifications",
+    "practitionerAddress": "practitioner_address",
+    "instituteName": "institute_name",
+    "instituteContact": "institute_contact",
+}
+
+
+@router.patch("/me", response_model=DoctorOut)
+def update_me(
+    payload: DoctorSelfUpdate,
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(require_role("doctor")),
+) -> DoctorOut:
+    """Partial self-update of the calling doctor's practice profile.
+
+    Only fields explicitly present in the payload are applied. Images
+    (rubber stamp, e-signature) are validated, uploaded to S3 and swapped;
+    the superseded object is deleted only after the row commits.
+    """
+    doctor = _current_doctor(db, user)
+    sent = payload.model_fields_set
+
+    for field, col in _SELF_TEXT_FIELDS.items():
+        if field in sent:
+            value = getattr(payload, field)
+            # An empty institute phone clears to NULL rather than storing "".
+            if field == "instituteContact" and not (value or "").strip():
+                value = None
+            setattr(doctor, col, value)
+
+    superseded: list[str] = []
+
+    if "rubberStampImage" in sent and payload.rubberStampImage:
+        stamp = decode_rubber_stamp(payload.rubberStampImage)
+        mime, ext = _sniff_stamp(stamp)
+        key = object_key("doctors/stamps", ext)
+        put_bytes(key, stamp, mime)
+        if doctor.rubber_stamp_key:
+            superseded.append(doctor.rubber_stamp_key)
+        doctor.rubber_stamp_key = key
+
+    # clearDefaultSignature wins over a supplied image, so a payload that
+    # sets both is unambiguous (clear).
+    if payload.clearDefaultSignature:
+        if doctor.default_signature_key:
+            superseded.append(doctor.default_signature_key)
+        doctor.default_signature_key = None
+    elif "defaultSignatureImage" in sent and payload.defaultSignatureImage:
+        sig = decode_signature(payload.defaultSignatureImage)
+        key = object_key("doctors/signatures", "png")
+        put_bytes(key, sig, "image/png")
+        if doctor.default_signature_key:
+            superseded.append(doctor.default_signature_key)
+        doctor.default_signature_key = key
+
+    db.commit()
+    db.refresh(doctor)
+    # Delete superseded objects only after the new keys are committed — a
+    # failed commit rolls back to the old keys, so they must stay alive.
+    for key in superseded:
+        delete_object(key)
+    return _self_out(db, doctor)
+
+
+@router.get("/me/signature")
+def get_my_signature(
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(require_role("doctor")),
+) -> Response:
+    """Stream the calling doctor's saved e-signature PNG (404 if none)."""
+    doctor = _current_doctor(db, user)
+    if not doctor.default_signature_key:
+        raise not_found("no_signature")
+    return Response(content=get_bytes(doctor.default_signature_key), media_type="image/png")
 
 
 @router.get("/{doctor_id}", response_model=DoctorDetailOut,

--- a/backend/app/routers/doctors.py
+++ b/backend/app/routers/doctors.py
@@ -85,7 +85,8 @@ REQUIRED_PRESCRIPTION_FIELDS = (
     "slmcRegistrationNumber",
     "qualifications",
     "practitionerAddress",
-    "instituteContact",
+    # instituteContact is intentionally absent — the institute phone is
+    # optional (§1.7 prescriptions are valid without it).
     "rubberStampImage",
 )
 
@@ -153,6 +154,14 @@ def create_doctor(
     stamp_key = object_key("doctors/stamps", ext)
     put_bytes(stamp_key, stamp, mime)
 
+    # Optional saved e-signature — validated + uploaded up front; only the
+    # key lands on the row. Absent for doctors who'll keep signing manually.
+    signature_key: str | None = None
+    if payload.defaultSignatureImage:
+        sig = decode_signature(payload.defaultSignatureImage)
+        signature_key = object_key("doctors/signatures", "png")
+        put_bytes(signature_key, sig, "image/png")
+
     # In invite mode, generate a random password that's effectively
     # un-guessable. The doctor will replace it via the onboarding flow;
     # the value never leaves this function (no log, no return).
@@ -174,8 +183,9 @@ def create_doctor(
         qualifications=payload.qualifications,
         practitioner_address=payload.practitionerAddress,
         institute_name=payload.instituteName,
-        institute_contact=payload.instituteContact,
+        institute_contact=payload.instituteContact or None,
         rubber_stamp_key=stamp_key,
+        default_signature_key=signature_key,
         active=True,
         created_at=now,
         # Legacy path is auto-approved — admin typed every field, there's

--- a/backend/app/routers/doctors.py
+++ b/backend/app/routers/doctors.py
@@ -651,6 +651,22 @@ def get_my_signature(
     return Response(content=get_bytes(doctor.default_signature_key), media_type="image/png")
 
 
+@router.get("/me/stamp")
+def get_my_stamp(
+    db: Session = Depends(db_dep),
+    user: CurrentUser = Depends(require_role("doctor")),
+) -> Response:
+    """Stream the calling doctor's rubber stamp image. Served as a stream
+    (not inlined into /doctors/me) so the profile page can show the existing
+    stamp without bloating every /me call the doctor pages make."""
+    doctor = _current_doctor(db, user)
+    if not doctor.rubber_stamp_key:
+        raise not_found("no_stamp")
+    data = get_bytes(doctor.rubber_stamp_key)
+    mime, _ = _sniff_stamp(data)
+    return Response(content=data, media_type=mime)
+
+
 @router.get("/{doctor_id}", response_model=DoctorDetailOut,
             dependencies=[Depends(require_role("admin", "doctor", "healthworker", "sys-admin"))])
 def get_doctor(doctor_id: int, db: Session = Depends(db_dep)) -> DoctorDetailOut:

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -679,7 +679,9 @@ FollowUp = Annotated[
 
 
 class ConsultationSubmitIn(BaseModel):
-    signature: str  # base64 / data url
+    # Optional: when omitted, the doctor's saved default e-signature is
+    # applied (a copy of its bytes). Required only if the doctor has none.
+    signature: Optional[str] = None  # base64 / data url
     followUp: Optional[FollowUp] = None
 
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -42,7 +42,8 @@ class DoctorBase(BaseModel):
     qualifications: str
     practitionerAddress: str
     instituteName: str
-    instituteContact: str
+    # Institute phone is optional (§1.7 prescriptions are valid without it).
+    instituteContact: Optional[str] = None
     rubberStampImage: str  # base64
 
 
@@ -53,6 +54,10 @@ class DoctorCreate(DoctorBase):
     # own. Requires the email service to be configured; the endpoint will
     # 422 `email_not_configured` otherwise.
     password: Optional[str] = None
+    # Optional saved e-signature, base64 data URL (same shape as the rubber
+    # stamp). When present the doctor can finalise consultations without
+    # drawing a signature each time.
+    defaultSignatureImage: Optional[str] = None
 
 
 class DoctorOnboardingPeek(BaseModel):
@@ -99,8 +104,12 @@ class DoctorOnboardingSubmit(BaseModel):
     qualifications: str
     practitionerAddress: str
     instituteName: str
-    instituteContact: str
+    # Institute phone is optional (§1.7 prescriptions are valid without it).
+    instituteContact: Optional[str] = None
     rubberStampImage: str  # base64
+    # Optional saved e-signature, base64 data URL. Lets the doctor skip
+    # drawing a signature on every consultation.
+    defaultSignatureImage: Optional[str] = None
 
 
 class DoctorInviteCreate(BaseModel):
@@ -135,6 +144,28 @@ class DoctorUpdate(BaseModel):
     active: Optional[bool] = None
 
 
+class DoctorSelfUpdate(BaseModel):
+    """Partial self-service profile update (PATCH /doctors/me).
+
+    Only the practice-profile fields a doctor may change themselves —
+    identity/credential fields (name, email, SLMC number) stay admin-only.
+    A field is applied only when explicitly present in the payload
+    (tracked via model_fields_set), so omission leaves it unchanged.
+
+    Image fields carry a base64 data URL to set/replace. To remove the
+    saved e-signature send clearDefaultSignature=true (a bare null on
+    defaultSignatureImage is treated as "unchanged", not "clear").
+    """
+    contact: Optional[str] = None
+    qualifications: Optional[str] = None
+    practitionerAddress: Optional[str] = None
+    instituteName: Optional[str] = None
+    instituteContact: Optional[str] = None
+    rubberStampImage: Optional[str] = None
+    defaultSignatureImage: Optional[str] = None
+    clearDefaultSignature: bool = False
+
+
 class DoctorOut(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True)
 
@@ -148,8 +179,16 @@ class DoctorOut(BaseModel):
     qualifications: str
     practitionerAddress: str = Field(validation_alias="practitioner_address")
     instituteName: str = Field(validation_alias="institute_name")
-    instituteContact: str = Field(validation_alias="institute_contact")
+    instituteContact: Optional[str] = Field(default=None, validation_alias="institute_contact")
+    # True when the doctor has saved a default e-signature. Derived from
+    # default_signature_key; the key itself is never exposed in JSON.
+    hasDefaultSignature: bool = Field(default=False, validation_alias="default_signature_key")
     active: bool
+
+    @field_validator("hasDefaultSignature", mode="before")
+    @classmethod
+    def _signature_key_to_bool(cls, v: Any) -> bool:
+        return bool(v)
     # Three-state lifecycle:
     #   "awaiting_setup"    → live unconsumed invite, doctor hasn't filled
     #                         out the form yet (or has filled it out and

--- a/backend/app/services/doctor_invites.py
+++ b/backend/app/services/doctor_invites.py
@@ -211,6 +211,7 @@ def consume_new_doctor(
     password: str,
     profile: dict,
     rubber_stamp: bytes,
+    default_signature: bytes | None = None,
 ) -> Doctor:
     """New mode: create Account + Doctor from the doctor's submission.
 
@@ -243,6 +244,14 @@ def consume_new_doctor(
     stamp_key = object_key("doctors/stamps", ext)
     put_bytes(stamp_key, rubber_stamp, mime)
 
+    # Optional saved e-signature — uploaded before the insert, same as the
+    # stamp, so a DB failure leaves a harmless orphan key rather than a row
+    # pointing at a missing object.
+    signature_key: str | None = None
+    if default_signature is not None:
+        signature_key = object_key("doctors/signatures", "png")
+        put_bytes(signature_key, default_signature, "image/png")
+
     now = datetime.now(timezone.utc)
     # If this email was rejected before, link the fresh submission back to
     # the most recent rejected attempt so the audit trail across re-tries
@@ -271,8 +280,9 @@ def consume_new_doctor(
         qualifications=profile["qualifications"],
         practitioner_address=profile["practitionerAddress"],
         institute_name=profile["instituteName"],
-        institute_contact=profile["instituteContact"],
+        institute_contact=profile.get("instituteContact") or None,
         rubber_stamp_key=stamp_key,
+        default_signature_key=signature_key,
         active=True,
         approved_at=None,  # awaits admin approval before login is allowed
         created_at=now,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -122,7 +122,13 @@ def _wipe_setup_state():
         # DELETE), silently suppressing the delete. We disable it for the
         # duration of the wipe. (See bug note in the feature-end summary.)
         db.execute(text("DELETE FROM appointment_attachments"))
+        # consultations_locked_guard (migration 0001) raises on UPDATE/DELETE
+        # of a completed consultation to enforce immutability. The wipe has to
+        # clear those too between tests, so disable it for the delete — same
+        # pattern as appointments_locked_guard below.
+        db.execute(text("ALTER TABLE consultations DISABLE TRIGGER consultations_locked_guard"))
         db.execute(text("DELETE FROM consultations"))
+        db.execute(text("ALTER TABLE consultations ENABLE TRIGGER consultations_locked_guard"))
         db.execute(text("DELETE FROM preconsultation"))
         db.execute(text("DELETE FROM consents"))
         db.execute(text("ALTER TABLE appointments DISABLE TRIGGER appointments_locked_guard"))

--- a/backend/tests/test_consultation_signature.py
+++ b/backend/tests/test_consultation_signature.py
@@ -1,0 +1,162 @@
+"""Consultation submit signature behaviour.
+
+A doctor may finalise a consultation by drawing a signature (as before) or,
+if they have saved a default e-signature, by omitting the signature — in
+which case a COPY of the saved bytes is stored on the consultation. The
+copy is what guarantees a later change to the saved signature can't mutate
+an already-signed consultation.
+"""
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timezone
+
+import pytest
+
+from app.database import SessionLocal
+from app.models import Account, Appointment, Consultation, Doctor, Patient
+from app.security import hash_password
+from app.services.storage import get_bytes, object_key, put_bytes
+
+
+_PNG_A = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+# A second, byte-distinct PNG (different IDAT) for the immutability test.
+_PNG_B = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\x10IDATx\x9cc``\xf8"
+    b"\xcf\xc0\xc0\xc0\x00\x00\x04\x00\x01\xff\xff?\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_PNG_A_URL = "data:image/png;base64," + base64.b64encode(_PNG_A).decode("ascii")
+_PNG_B_URL = "data:image/png;base64," + base64.b64encode(_PNG_B).decode("ascii")
+
+_CREDS = ("dr_sig", "DrSig-Password-123")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+@pytest.fixture
+def scenario(initialized_system):
+    """Seed a doctor (known password), patient, in_progress appointment, and
+    a draft consultation. Returns (doctor_id, consultation_id)."""
+    db = SessionLocal()
+    try:
+        db.add(Account(username=_CREDS[0], password=hash_password(_CREDS[1]), role="doctor"))
+        doctor = Doctor(
+            username=_CREDS[0],
+            given_name="Sig", family_name="Doc",
+            contact="+94 11 555 0000",
+            email="dr_sig@example.com",
+            slmc_registration_number="SLMC-SIG-1",
+            qualifications="MBBS",
+            practitioner_address="5 Sig St",
+            institute_name="Sig Clinic",
+            rubber_stamp_key="test/stub-stamp-key.png",
+            active=True,
+            approved_at=datetime.now(timezone.utc),
+        )
+        patient = Patient(given_name="Pat", family_name="Ient", gender="female")
+        db.add(doctor)
+        db.add(patient)
+        db.flush()
+        appt = Appointment(
+            patient_id=patient.patient_id,
+            doctor_id=doctor.doctor_id,
+            scheduled_at=datetime.now(timezone.utc),
+            status="in_progress",
+        )
+        db.add(appt)
+        db.flush()
+        consult = Consultation(appointment_id=appt.appointment_id, status="draft")
+        db.add(consult)
+        db.commit()
+        return doctor.doctor_id, consult.consultation_id
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def doctor_client(client, scenario):
+    r = client.post("/auth/login", json={"username": _CREDS[0], "password": _CREDS[1]})
+    assert r.status_code == 200, r.text
+    return client
+
+
+def _set_saved_signature(doctor_id: int, png: bytes) -> None:
+    """Attach a saved e-signature to the doctor, bypassing the API."""
+    key = object_key("doctors/signatures", "png")
+    put_bytes(key, png, "image/png")
+    db = SessionLocal()
+    try:
+        d = db.get(Doctor, doctor_id)
+        d.default_signature_key = key
+        db.commit()
+    finally:
+        db.close()
+
+
+def _consultation_signature_bytes(cid: int) -> bytes | None:
+    db = SessionLocal()
+    try:
+        c = db.get(Consultation, cid)
+        if not c.signature_key:
+            return None
+        return get_bytes(c.signature_key)
+    finally:
+        db.close()
+
+
+def test_submit_with_explicit_signature(doctor_client, scenario):
+    _, cid = scenario
+    r = doctor_client.post(
+        f"/consultations/{cid}/submit", json={"signature": _PNG_A_URL},
+        headers=_csrf(doctor_client),
+    )
+    assert r.status_code == 200, r.text
+    assert _consultation_signature_bytes(cid) == _PNG_A
+
+
+def test_submit_omitted_without_default_is_422(doctor_client, scenario):
+    _, cid = scenario
+    r = doctor_client.post(
+        f"/consultations/{cid}/submit", json={}, headers=_csrf(doctor_client)
+    )
+    assert r.status_code == 422, r.text
+
+
+def test_submit_omitted_uses_saved_default(doctor_client, scenario):
+    doctor_id, cid = scenario
+    _set_saved_signature(doctor_id, _PNG_A)
+    r = doctor_client.post(
+        f"/consultations/{cid}/submit", json={}, headers=_csrf(doctor_client)
+    )
+    assert r.status_code == 200, r.text
+    # A copy of the saved bytes is stored under a fresh per-consultation key.
+    assert _consultation_signature_bytes(cid) == _PNG_A
+    db = SessionLocal()
+    try:
+        c = db.get(Consultation, cid)
+        d = db.get(Doctor, doctor_id)
+        assert c.signature_key != d.default_signature_key  # distinct object
+    finally:
+        db.close()
+
+
+def test_saved_signature_change_does_not_mutate_completed(doctor_client, scenario):
+    doctor_id, cid = scenario
+    _set_saved_signature(doctor_id, _PNG_A)
+    doctor_client.post(
+        f"/consultations/{cid}/submit", json={}, headers=_csrf(doctor_client)
+    )
+    before = _consultation_signature_bytes(cid)
+    # Doctor later changes their saved signature to a different image.
+    _set_saved_signature(doctor_id, _PNG_B)
+    after = _consultation_signature_bytes(cid)
+    assert before == after == _PNG_A  # the signed consultation is immutable

--- a/backend/tests/test_doctor_esignature_registration.py
+++ b/backend/tests/test_doctor_esignature_registration.py
@@ -1,0 +1,125 @@
+"""Registration / onboarding: optional institute phone + optional saved
+e-signature at sign-up.
+
+Covers both creation paths:
+  - admin POST /doctors (legacy fill-everything)
+  - doctor self-onboarding POST /doctor-onboarding/{token}
+"""
+from __future__ import annotations
+
+import base64
+
+from app.database import SessionLocal
+from app.models import Doctor
+from app.services import doctor_invites
+
+
+_PNG_1x1 = base64.b64encode(
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+).decode("ascii")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+def _create_payload(**overrides) -> dict:
+    base = {
+        "username": "dr_reg",
+        "password": "DrReg-Password-123",
+        "givenName": "Nadia",
+        "familyName": "Fernando",
+        "contact": "+94 11 333 0000",
+        "email": "dr_reg@example.com",
+        "slmcRegistrationNumber": "SLMC-REG-1",
+        "qualifications": "MBBS",
+        "practitionerAddress": "3 Reg Rd",
+        "instituteName": "Reg Clinic",
+        "instituteContact": "+94 11 333 1111",
+        "rubberStampImage": _PNG_1x1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _onboard_payload(**overrides) -> dict:
+    base = {
+        "username": "dr_onb",
+        "password": "DrOnb-Password-123",
+        "givenName": "Ravi",
+        "familyName": "Jay",
+        "contact": "+94 11 444 0000",
+        "slmcRegistrationNumber": "SLMC-ONB-1",
+        "qualifications": "MBBS",
+        "practitionerAddress": "4 Onb Rd",
+        "instituteName": "Onb Clinic",
+        "instituteContact": "+94 11 444 1111",
+        "rubberStampImage": _PNG_1x1,
+    }
+    base.update(overrides)
+    return base
+
+
+def _new_doctor_token(email: str) -> str:
+    db = SessionLocal()
+    try:
+        _, raw = doctor_invites.issue_new_doctor(db, email=email, family_name=None)
+    finally:
+        db.close()
+    return raw
+
+
+# ── admin POST /doctors ──────────────────────────────────────────────────
+
+def test_register_without_institute_contact_succeeds(admin_client):
+    payload = _create_payload()
+    payload.pop("instituteContact")
+    r = admin_client.post("/doctors", json=payload, headers=_csrf(admin_client))
+    assert r.status_code == 201, r.text
+    assert r.json()["instituteContact"] is None
+
+
+def test_register_with_default_signature_sets_flag(admin_client):
+    payload = _create_payload(defaultSignatureImage=_PNG_1x1)
+    r = admin_client.post("/doctors", json=payload, headers=_csrf(admin_client))
+    assert r.status_code == 201, r.text
+    assert r.json()["hasDefaultSignature"] is True
+
+
+def test_register_without_signature_leaves_flag_false(admin_client):
+    r = admin_client.post("/doctors", json=_create_payload(), headers=_csrf(admin_client))
+    assert r.status_code == 201, r.text
+    assert r.json()["hasDefaultSignature"] is False
+
+
+# ── self-onboarding POST /doctor-onboarding/{token} ──────────────────────
+
+def test_onboard_without_institute_contact_succeeds(client, initialized_system):
+    raw = _new_doctor_token("onb_no_phone@example.com")
+    payload = _onboard_payload()
+    payload.pop("instituteContact")
+    r = client.post(f"/doctor-onboarding/{raw}", json=payload)
+    assert r.status_code == 204, r.text
+    db = SessionLocal()
+    try:
+        doctor = db.query(Doctor).filter_by(username="dr_onb").first()
+        assert doctor is not None and doctor.institute_contact is None
+    finally:
+        db.close()
+
+
+def test_onboard_with_default_signature_stores_key(client, initialized_system):
+    raw = _new_doctor_token("onb_sig@example.com")
+    payload = _onboard_payload(defaultSignatureImage=_PNG_1x1)
+    r = client.post(f"/doctor-onboarding/{raw}", json=payload)
+    assert r.status_code == 204, r.text
+    db = SessionLocal()
+    try:
+        doctor = db.query(Doctor).filter_by(username="dr_onb").first()
+        assert doctor is not None and doctor.default_signature_key is not None
+    finally:
+        db.close()

--- a/backend/tests/test_doctors_me.py
+++ b/backend/tests/test_doctors_me.py
@@ -1,0 +1,133 @@
+"""Doctor self-service profile: GET/PATCH /doctors/me and the saved
+e-signature stream (GET /doctors/me/signature).
+
+A doctor may edit their own practice-profile fields and manage a saved
+e-signature; identity/credential fields stay admin-only, and only the
+doctor themselves (not admins/healthworkers) can reach these routes.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from app.database import SessionLocal
+from app.models import Account, Doctor
+from app.security import hash_password
+
+
+_PNG_1x1_BYTES = (
+    b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01\x00\x00\x00\x01"
+    b"\x08\x06\x00\x00\x00\x1f\x15\xc4\x89\x00\x00\x00\rIDATx\x9cc\xf8\xff"
+    b"\xff?\x00\x05\xfe\x02\xfe\x9a\x9c\xa9\x83\x00\x00\x00\x00IEND\xaeB`\x82"
+)
+_PNG_DATA_URL = "data:image/png;base64," + base64.b64encode(_PNG_1x1_BYTES).decode("ascii")
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+_DR_CREDS = ("dr_me", "DrMe-Password-123")
+
+
+@pytest.fixture
+def doctor_account(initialized_system):
+    """Seed an approved doctor with a KNOWN password so we can log in."""
+    db = SessionLocal()
+    try:
+        from datetime import datetime, timezone
+
+        db.add(Account(
+            username=_DR_CREDS[0],
+            password=hash_password(_DR_CREDS[1]),
+            role="doctor",
+        ))
+        db.add(Doctor(
+            username=_DR_CREDS[0],
+            given_name="Mara", family_name="Perera",
+            contact="+94 11 222 0000",
+            email="dr_me@example.com",
+            slmc_registration_number="SLMC-ME-1",
+            qualifications="MBBS",
+            practitioner_address="2 Self St",
+            institute_name="Self Clinic",
+            institute_contact="+94 11 222 1111",
+            rubber_stamp_key="test/stub-stamp-key.png",
+            active=True,
+            approved_at=datetime.now(timezone.utc),
+        ))
+        db.commit()
+    finally:
+        db.close()
+    return _DR_CREDS
+
+
+@pytest.fixture
+def doctor_client(client, doctor_account):
+    username, password = doctor_account
+    r = client.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return client
+
+
+def test_get_me_returns_own_profile(doctor_client):
+    r = doctor_client.get("/doctors/me")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["email"] == "dr_me@example.com"
+    assert body["hasDefaultSignature"] is False
+
+
+def test_get_me_forbidden_for_non_doctor(admin_client):
+    assert admin_client.get("/doctors/me").status_code == 403
+
+
+def test_patch_me_updates_editable_fields(doctor_client):
+    r = doctor_client.patch(
+        "/doctors/me", json={"qualifications": "MBBS, MD"}, headers=_csrf(doctor_client)
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["qualifications"] == "MBBS, MD"
+
+
+def test_patch_me_ignores_locked_fields(doctor_client):
+    # email is not part of DoctorSelfUpdate — it must be ignored, not applied.
+    doctor_client.patch(
+        "/doctors/me", json={"email": "evil@example.com"}, headers=_csrf(doctor_client)
+    )
+    assert doctor_client.get("/doctors/me").json()["email"] == "dr_me@example.com"
+
+
+def test_patch_me_clears_institute_contact(doctor_client):
+    r = doctor_client.patch(
+        "/doctors/me", json={"instituteContact": ""}, headers=_csrf(doctor_client)
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["instituteContact"] is None
+
+
+def test_patch_me_set_and_clear_signature(doctor_client):
+    doctor_client.patch(
+        "/doctors/me", json={"defaultSignatureImage": _PNG_DATA_URL},
+        headers=_csrf(doctor_client),
+    )
+    assert doctor_client.get("/doctors/me").json()["hasDefaultSignature"] is True
+    doctor_client.patch(
+        "/doctors/me", json={"clearDefaultSignature": True}, headers=_csrf(doctor_client)
+    )
+    assert doctor_client.get("/doctors/me").json()["hasDefaultSignature"] is False
+
+
+def test_get_me_signature_streams_then_404(doctor_client):
+    assert doctor_client.get("/doctors/me/signature").status_code == 404
+    doctor_client.patch(
+        "/doctors/me", json={"defaultSignatureImage": _PNG_DATA_URL},
+        headers=_csrf(doctor_client),
+    )
+    r = doctor_client.get("/doctors/me/signature")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/png"
+    assert r.content == _PNG_1x1_BYTES

--- a/backend/tests/test_doctors_me.py
+++ b/backend/tests/test_doctors_me.py
@@ -121,6 +121,17 @@ def test_patch_me_set_and_clear_signature(doctor_client):
     assert doctor_client.get("/doctors/me").json()["hasDefaultSignature"] is False
 
 
+def test_get_me_stamp_streams(doctor_client):
+    # Upload a stamp via self-update, then it should stream back.
+    doctor_client.patch(
+        "/doctors/me", json={"rubberStampImage": _PNG_DATA_URL}, headers=_csrf(doctor_client)
+    )
+    r = doctor_client.get("/doctors/me/stamp")
+    assert r.status_code == 200
+    assert r.headers["content-type"] == "image/png"
+    assert r.content == _PNG_1x1_BYTES
+
+
 def test_get_me_signature_streams_then_404(doctor_client):
     assert doctor_client.get("/doctors/me/signature").status_code == 404
     doctor_client.patch(

--- a/frontend/src/app/(app)/admin/doctors/new/page.tsx
+++ b/frontend/src/app/(app)/admin/doctors/new/page.tsx
@@ -192,6 +192,7 @@ function ManualPanel({
             instituteName: payload.instituteName,
             instituteContact: payload.instituteContact,
             rubberStampImage: payload.rubberStampImage!,
+            defaultSignatureImage: payload.defaultSignatureImage,
           },
           { onSuccess: (doc) => onCreated(doc.id) },
         );

--- a/frontend/src/app/(app)/doctor/profile/page.tsx
+++ b/frontend/src/app/(app)/doctor/profile/page.tsx
@@ -13,6 +13,7 @@ import { RubberStampUploader } from "@/components/admin/rubber-stamp-uploader";
 import { SignatureInput } from "@/components/doctor/signature-input";
 import {
   MY_SIGNATURE_URL,
+  MY_STAMP_URL,
   useCurrentDoctor,
   useUpdateMyProfile,
   type DoctorSelfUpdateRequest,
@@ -41,9 +42,10 @@ export default function DoctorProfilePage() {
     instituteName: "",
     instituteContact: "",
   });
-  // A freshly captured rubber stamp / signature to send. `undefined` = leave
-  // the stored one untouched; for the signature, `clearSignature` removes it.
-  const [stamp, setStamp] = useState<string | null>(null);
+  // Seed the uploader with the existing stamp streamed from the server; it's
+  // only resent when the doctor actually replaces it (stampDirty). Once
+  // replaced, `stamp` holds the new data URL instead of the URL.
+  const [stamp, setStamp] = useState<string | null>(MY_STAMP_URL);
   const [stampDirty, setStampDirty] = useState(false);
   const [signature, setSignature] = useState<string | null>(null);
   const [clearSignature, setClearSignature] = useState(false);

--- a/frontend/src/app/(app)/doctor/profile/page.tsx
+++ b/frontend/src/app/(app)/doctor/profile/page.tsx
@@ -1,0 +1,307 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2, PenLine, Save } from "lucide-react";
+
+import { Button } from "@/components/primitives/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/primitives/card";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { Input, Label } from "@/components/primitives/input";
+import { PageHeader } from "@/components/primitives/page-header";
+import { Textarea } from "@/components/primitives/select";
+import { RubberStampUploader } from "@/components/admin/rubber-stamp-uploader";
+import { SignatureInput } from "@/components/doctor/signature-input";
+import {
+  MY_SIGNATURE_URL,
+  useCurrentDoctor,
+  useUpdateMyProfile,
+  type DoctorSelfUpdateRequest,
+} from "@/lib/use-api";
+import { explainError } from "@/lib/error-codes";
+
+// Editable practice-profile fields a doctor controls themselves. Identity and
+// credential fields (name, email, SLMC number) are admin-only and shown
+// read-only below.
+type EditableText = {
+  contact: string;
+  qualifications: string;
+  practitionerAddress: string;
+  instituteName: string;
+  instituteContact: string;
+};
+
+export default function DoctorProfilePage() {
+  const { doctor, hasDefaultSignature, isLoading, error, refetch } = useCurrentDoctor();
+  const update = useUpdateMyProfile();
+
+  const [text, setText] = useState<EditableText>({
+    contact: "",
+    qualifications: "",
+    practitionerAddress: "",
+    instituteName: "",
+    instituteContact: "",
+  });
+  // A freshly captured rubber stamp / signature to send. `undefined` = leave
+  // the stored one untouched; for the signature, `clearSignature` removes it.
+  const [stamp, setStamp] = useState<string | null>(null);
+  const [stampDirty, setStampDirty] = useState(false);
+  const [signature, setSignature] = useState<string | null>(null);
+  const [clearSignature, setClearSignature] = useState(false);
+  const [replacingSignature, setReplacingSignature] = useState(false);
+  // Cache-buster so the <img> reloads after a replace/clear round-trips.
+  const [sigVersion, setSigVersion] = useState(0);
+  const [saved, setSaved] = useState(false);
+
+  // Hydrate the editable fields once the profile lands.
+  useEffect(() => {
+    if (doctor) {
+      setText({
+        contact: doctor.contact ?? "",
+        qualifications: doctor.qualifications ?? "",
+        practitionerAddress: doctor.practitionerAddress ?? "",
+        instituteName: doctor.instituteName ?? "",
+        instituteContact: doctor.instituteContact ?? "",
+      });
+    }
+  }, [doctor]);
+
+  const setField = (key: keyof EditableText) => (e: { target: { value: string } }) => {
+    setText((t) => ({ ...t, [key]: e.target.value }));
+    setSaved(false);
+  };
+
+  const onSave = () => {
+    setSaved(false);
+    const body: DoctorSelfUpdateRequest = {
+      contact: text.contact.trim(),
+      qualifications: text.qualifications.trim(),
+      practitionerAddress: text.practitionerAddress.trim(),
+      instituteName: text.instituteName.trim(),
+      instituteContact: text.instituteContact.trim(),
+    };
+    if (stampDirty && stamp) body.rubberStampImage = stamp;
+    if (clearSignature) body.clearDefaultSignature = true;
+    else if (signature) body.defaultSignatureImage = signature;
+
+    update.mutate(body, {
+      onSuccess: () => {
+        setSaved(true);
+        setSignature(null);
+        setClearSignature(false);
+        setReplacingSignature(false);
+        setStampDirty(false);
+        setSigVersion((v) => v + 1);
+        refetch();
+      },
+    });
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center gap-2 text-[var(--muted-foreground)]">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading your profile…
+      </div>
+    );
+  }
+
+  if (error || !doctor) {
+    return <ErrorBanner>{explainError((error as { error?: string })?.error ?? "", "Couldn't load your profile.")}</ErrorBanner>;
+  }
+
+  // The saved signature shows once it exists server-side and isn't being
+  // cleared/replaced this session.
+  const showSavedSignature = hasDefaultSignature && !clearSignature && !replacingSignature && !signature;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <PageHeader
+        label="Doctor"
+        title="My profile"
+        subtitle="Update your practice details, rubber stamp, and saved e-signature."
+        action={
+          <Button onClick={onSave} disabled={update.isPending}>
+            {update.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+            {update.isPending ? "Saving…" : "Save changes"}
+          </Button>
+        }
+      />
+
+      {update.isError && (
+        <ErrorBanner>{explainError(update.error?.error ?? "", "Couldn't save your changes.")}</ErrorBanner>
+      )}
+      {saved && (
+        <div className="rounded-xl border border-emerald-500/30 bg-emerald-500/5 px-4 py-3 text-sm text-emerald-700">
+          Profile saved.
+        </div>
+      )}
+
+      {/* Read-only identity — changed by an admin only. */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Identity</CardTitle>
+          <CardDescription>Managed by your administrator. Contact them to change these.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <ReadOnly label="Name" value={`${doctor.givenName} ${doctor.familyName}`} />
+          <ReadOnly label="Email" value={doctor.email} />
+          <ReadOnly label="SLMC registration number" value={doctor.slmcRegistrationNumber} />
+          <ReadOnly label="Username" value={doctor.username} mono />
+        </CardContent>
+      </Card>
+
+      {/* Editable practice profile. */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Practice details</CardTitle>
+          <CardDescription>Reproduced on the prescription PDFs you sign.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 sm:grid-cols-2">
+          <FieldText label="Contact number" value={text.contact} onChange={setField("contact")} />
+          <FieldText label="Institute name" value={text.instituteName} onChange={setField("instituteName")} />
+          <FieldText
+            label="Institute contact"
+            value={text.instituteContact}
+            onChange={setField("instituteContact")}
+            placeholder="Optional"
+          />
+          <FieldArea label="Qualifications" value={text.qualifications} onChange={setField("qualifications")} />
+          <FieldArea
+            label="Practitioner address"
+            value={text.practitionerAddress}
+            onChange={setField("practitionerAddress")}
+          />
+        </CardContent>
+      </Card>
+
+      {/* Rubber stamp. */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Rubber stamp</CardTitle>
+          <CardDescription>Replace only if you need to update the existing stamp.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RubberStampUploader
+            value={stamp}
+            onChange={(next) => {
+              setStamp(next);
+              setStampDirty(true);
+              setSaved(false);
+            }}
+            enableQrCapture
+          />
+        </CardContent>
+      </Card>
+
+      {/* Saved e-signature. */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Default e-signature</CardTitle>
+          <CardDescription>
+            When set, it&rsquo;s applied automatically on every consultation — no need to sign each time. You can still
+            draw a one-off signature per consultation.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {showSavedSignature ? (
+            <div className="flex items-center gap-4 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+              <div className="flex h-20 w-40 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[var(--border)] bg-white">
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={`${MY_SIGNATURE_URL}?v=${sigVersion}`}
+                  alt="Your saved e-signature"
+                  className="max-h-full max-w-full object-contain"
+                />
+              </div>
+              <div className="flex-1">
+                <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-emerald-600">Signature on file</div>
+                <p className="mt-1 text-sm text-[var(--muted-foreground)]">Applied automatically when you finalise a consultation.</p>
+              </div>
+              <div className="flex flex-col gap-1.5">
+                <Button type="button" variant="secondary" size="sm" onClick={() => setReplacingSignature(true)}>
+                  <PenLine className="h-3.5 w-3.5" />
+                  Replace
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => {
+                    setClearSignature(true);
+                    setSignature(null);
+                    setSaved(false);
+                  }}
+                >
+                  Clear
+                </Button>
+              </div>
+            </div>
+          ) : clearSignature ? (
+            <div className="flex items-center justify-between rounded-xl border border-[var(--border)] bg-[var(--muted)]/20 p-4 text-sm">
+              <span className="text-[var(--muted-foreground)]">Saved signature will be removed when you save.</span>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setClearSignature(false)}>
+                Undo
+              </Button>
+            </div>
+          ) : (
+            <SignatureInput
+              value={signature}
+              onChange={(next) => {
+                setSignature(next);
+                setSaved(false);
+                if (!next) setReplacingSignature(false);
+              }}
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function ReadOnly({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>{label}</Label>
+      <div className={`rounded-xl border border-[var(--border)] bg-[var(--muted)]/40 px-4 py-3 text-sm ${mono ? "font-mono" : ""}`}>
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function FieldText({
+  label,
+  value,
+  onChange,
+  placeholder,
+}: {
+  label: string;
+  value: string;
+  onChange: (e: { target: { value: string } }) => void;
+  placeholder?: string;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <Label>{label}</Label>
+      <Input value={value} onChange={onChange} autoComplete="off" placeholder={placeholder} />
+    </div>
+  );
+}
+
+function FieldArea({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onChange: (e: { target: { value: string } }) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2 sm:col-span-2">
+      <Label>{label}</Label>
+      <Textarea rows={3} value={value} onChange={onChange} autoComplete="off" />
+    </div>
+  );
+}

--- a/frontend/src/app/doctor-onboarding/[token]/page.tsx
+++ b/frontend/src/app/doctor-onboarding/[token]/page.tsx
@@ -407,6 +407,7 @@ function NewDoctorPanel({
           instituteName: payload.instituteName,
           instituteContact: payload.instituteContact,
           rubberStampImage: payload.rubberStampImage,
+          defaultSignatureImage: payload.defaultSignatureImage,
         },
         skipAuthRedirect: true,
       });

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -4,13 +4,14 @@ import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { useState } from "react";
 import { z } from "zod";
-import { BadgeCheck, ContactRound, IdCard, Mail, Stamp } from "lucide-react";
+import { BadgeCheck, ContactRound, IdCard, Mail, PenLine, Stamp } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { Input, Label } from "@/components/primitives/input";
 import { Textarea } from "@/components/primitives/select";
 import { RubberStampUploader } from "@/components/admin/rubber-stamp-uploader";
+import { SignatureInput } from "@/components/doctor/signature-input";
 import type { Doctor } from "@/types/api";
 
 // Mode-aware schema — username + password are required at create time, omitted/optional on edit.
@@ -24,7 +25,8 @@ const baseFields = {
   qualifications: z.string().min(1, "Qualifications are required (§1.7)"),
   practitionerAddress: z.string().min(1, "Practitioner address is required (§1.7)"),
   instituteName: z.string().min(1, "Institute name is required"),
-  instituteContact: z.string().min(1, "Institute contact is required (§1.7)"),
+  // Institute phone is optional — §1.7 prescriptions are valid without it.
+  instituteContact: z.string().optional(),
 };
 
 // Password validity now depends on `onboardingMode`. Zod can't peek at
@@ -53,8 +55,10 @@ export type DoctorFormPayload = {
   qualifications: string;
   practitionerAddress: string;
   instituteName: string;
-  instituteContact: string;
+  instituteContact?: string;
   rubberStampImage?: string; // base64 — required on create, optional on update
+  // base64 PNG saved e-signature — only captured on create / self-onboarding.
+  defaultSignatureImage?: string;
   username?: string; // create only
   password?: string;
 };
@@ -94,6 +98,9 @@ export function DoctorForm({
   const [stamp, setStamp] = useState<string | null>(initial?.rubberStampImage ?? null);
   const [stampDirty, setStampDirty] = useState(false);
   const [stampError, setStampError] = useState<string | null>(null);
+  // Optional saved e-signature, captured on create / self-onboarding only.
+  // null = none provided (the doctor will sign each consultation by hand).
+  const [signature, setSignature] = useState<string | null>(null);
   // Onboarding-mode picker. "invite" (default) tells the backend to email
   // the doctor a link to set their own password. "manual" preserves the
   // legacy flow — admin types the password and shares it offline. Only
@@ -164,11 +171,13 @@ export function DoctorForm({
       qualifications: v.qualifications.trim(),
       practitionerAddress: v.practitionerAddress.trim(),
       instituteName: v.instituteName.trim(),
-      instituteContact: v.instituteContact.trim(),
+      instituteContact: v.instituteContact?.trim() || undefined,
       rubberStampImage: stampToSend ?? undefined,
     };
     if (isCreate) {
       payload.username = v.username?.trim();
+      // Saved e-signature is optional and only captured on create paths.
+      if (signature) payload.defaultSignatureImage = signature;
       if (isSelfOnboarding) {
         // Self-onboarding: password is always sent (validated above).
         payload.password = v.password;
@@ -286,7 +295,7 @@ export function DoctorForm({
       <Section
         Icon={BadgeCheck}
         title="Sri Lanka §1.7 prescription requirements"
-        hint="These five fields plus the rubber stamp are reproduced verbatim on every prescription PDF this doctor signs. They're required at account creation."
+        hint="These fields plus the rubber stamp are reproduced on every prescription PDF this doctor signs. All are required at account creation except the institute phone."
       >
         {/* autoComplete="off" everywhere in this section — browsers see
             field ids like "practitionerAddress" / "instituteName" and
@@ -305,11 +314,11 @@ export function DoctorForm({
             <Input id="instituteName" autoComplete="off" {...register("instituteName")} />
           </Field>
           <Field
-            label="Institute contact *"
+            label="Institute contact"
             htmlFor="instituteContact"
             error={errors.instituteContact?.message}
           >
-            <Input id="instituteContact" autoComplete="off" {...register("instituteContact")} />
+            <Input id="instituteContact" autoComplete="off" {...register("instituteContact")} placeholder="Optional" />
           </Field>
           <Field label="Qualifications *" htmlFor="qualifications" full error={errors.qualifications?.message}>
             <Textarea id="qualifications" rows={3} autoComplete="off" {...register("qualifications")} placeholder="e.g. MBBS, MD" />
@@ -335,6 +344,16 @@ export function DoctorForm({
         />
         {stampError && <p className="mt-2 text-xs text-rose-600">{stampError}</p>}
       </Section>
+
+      {isCreate && (
+        <Section
+          Icon={PenLine}
+          title="Default e-signature"
+          hint="Optional. Save a signature once and it's applied automatically on every consultation — no need to sign each time. You can still draw a one-off signature per consultation, and you can add or change this later from your profile."
+        >
+          <SignatureInput value={signature} onChange={setSignature} />
+        </Section>
+      )}
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
         {onCancel && (

--- a/frontend/src/components/admin/rubber-stamp-editor.tsx
+++ b/frontend/src/components/admin/rubber-stamp-editor.tsx
@@ -13,10 +13,13 @@ export function RubberStampEditor({
   source,
   onCancel,
   onSave,
+  description = "Crop the stamp tightly. Optionally remove the white paper background so it lays cleanly on the prescription.",
 }: {
   source: string;
   onCancel: () => void;
   onSave: (next: string) => void;
+  // Overridable so the same editor reads correctly for signatures too.
+  description?: string;
 }) {
   const imgRef = useRef<HTMLImageElement>(null);
   const previewRef = useRef<HTMLCanvasElement>(null);
@@ -93,9 +96,7 @@ export function RubberStampEditor({
 
   return (
     <div className="flex flex-col gap-5">
-      <p className="text-sm text-[var(--muted-foreground)]">
-        Crop the stamp tightly. Optionally remove the white paper background so it lays cleanly on the prescription.
-      </p>
+      <p className="text-sm text-[var(--muted-foreground)]">{description}</p>
 
       <div className="grid gap-5 lg:grid-cols-[minmax(0,1fr)_220px]">
         <div className="flex flex-col gap-3">

--- a/frontend/src/components/doctor/consultation-flow.tsx
+++ b/frontend/src/components/doctor/consultation-flow.tsx
@@ -31,7 +31,7 @@ import {
 } from "@/components/doctor/signature-canvas";
 import { explainError } from "@/lib/error-codes";
 import { appLocalToUtcIso, fmtRelative } from "@/lib/format";
-import { useCurrentDoctor, useSubmitConsultation, useUpdateConsultation } from "@/lib/use-api";
+import { MY_SIGNATURE_URL, useCurrentDoctor, useSubmitConsultation, useUpdateConsultation } from "@/lib/use-api";
 import type { Consultation, FollowUpInput } from "@/types/api";
 import { cn } from "@/lib/cn";
 
@@ -143,6 +143,9 @@ export function ConsultationFlow({
   const [signed, setSigned] = useState(false);
   const sigRef = useRef<SignatureCanvasHandle>(null);
   const [savedAt, setSavedAt] = useState<string | null>(null);
+  // When the doctor has a saved e-signature we apply it automatically; this
+  // flips true if they'd rather draw a one-off signature for this consult.
+  const [drawOneOff, setDrawOneOff] = useState(false);
 
   // Three-way follow-up choice at submit. Default: none.
   type FollowUpChoice = "none" | "appointment" | "weeks";
@@ -150,9 +153,11 @@ export function ConsultationFlow({
   const [followUpAt, setFollowUpAt] = useState<string>(""); // datetime-local
   const [followUpWeeks, setFollowUpWeeks] = useState<number>(4);
 
-  const { doctor } = useCurrentDoctor();
+  const { doctor, hasDefaultSignature } = useCurrentDoctor();
   const update = useUpdateConsultation(consultation.id);
   const submit = useSubmitConsultation(consultation.id);
+  // Draw the signature when there's no saved default, or the doctor opted to.
+  const drawingSignature = !hasDefaultSignature || drawOneOff;
 
   const form = useForm<ConsultationFormShape>({
     resolver: zodResolver(formSchema) as never,
@@ -177,8 +182,14 @@ export function ConsultationFlow({
   const back = () => setStage(stage === "review" ? "rx" : "notes");
 
   const onSubmit = async () => {
-    const sig = sigRef.current?.toDataURL();
-    if (!sig) return;
+    // When drawing, a signature is required; otherwise omit it so the backend
+    // applies the doctor's saved default e-signature.
+    let signature: string | undefined;
+    if (drawingSignature) {
+      const sig = sigRef.current?.toDataURL();
+      if (!sig) return;
+      signature = sig;
+    }
     // Final patch in case anything's dirty since the last save.
     await update.mutateAsync(toPatch(form.getValues()));
     let followUp: FollowUpInput | undefined;
@@ -188,7 +199,7 @@ export function ConsultationFlow({
       followUp = { kind: "weeks", weeks: followUpWeeks };
     }
     submit.mutate(
-      { signature: sig, followUp },
+      { signature, followUp },
       {
         onSuccess: () => router.push(`/doctor/appointments/${appointmentId}`),
       },
@@ -342,7 +353,46 @@ export function ConsultationFlow({
 
               <div className="flex flex-col gap-2">
                 <Label htmlFor="sig">Signature *</Label>
-                <SignatureCanvas ref={sigRef} onChange={setSigned} />
+                {drawingSignature ? (
+                  <>
+                    <SignatureCanvas ref={sigRef} onChange={setSigned} />
+                    {hasDefaultSignature && (
+                      <button
+                        type="button"
+                        onClick={() => setDrawOneOff(false)}
+                        className="self-start text-xs font-medium text-[var(--accent)] hover:underline"
+                      >
+                        Use my saved signature instead
+                      </button>
+                    )}
+                  </>
+                ) : (
+                  <div className="flex items-center gap-4 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+                    <div className="flex h-20 w-40 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[var(--border)] bg-white">
+                      {/* eslint-disable-next-line @next/next/no-img-element */}
+                      <img
+                        src={MY_SIGNATURE_URL}
+                        alt="Your saved e-signature"
+                        className="max-h-full max-w-full object-contain"
+                      />
+                    </div>
+                    <div className="flex-1">
+                      <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-emerald-600">
+                        Saved signature
+                      </div>
+                      <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+                        Applied automatically when you submit.
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => setDrawOneOff(true)}
+                      className="text-xs font-medium text-[var(--accent)] hover:underline"
+                    >
+                      Draw a one-off signature instead
+                    </button>
+                  </div>
+                )}
               </div>
             </Card>
           </div>
@@ -383,7 +433,7 @@ export function ConsultationFlow({
               <Button
                 type="button"
                 onClick={onSubmit}
-                disabled={!signed || !medsValid || !followUpReady || submit.isPending}
+                disabled={(drawingSignature && !signed) || !medsValid || !followUpReady || submit.isPending}
               >
                 <FileSignature className="h-4 w-4" />
                 {submit.isPending ? "Submitting…" : "Sign & submit"}

--- a/frontend/src/components/doctor/nav.tsx
+++ b/frontend/src/components/doctor/nav.tsx
@@ -2,13 +2,14 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { CalendarDays, Clock } from "lucide-react";
+import { CalendarDays, Clock, UserCog } from "lucide-react";
 
 import { cn } from "@/lib/cn";
 
 const NAV = [
   { href: "/doctor", label: "Calendar", Icon: CalendarDays, exact: true },
   { href: "/doctor/availability", label: "Availability", Icon: Clock },
+  { href: "/doctor/profile", label: "Profile", Icon: UserCog },
 ];
 
 // Doctor section is calendar-centric — kept open for adding history/profile

--- a/frontend/src/components/doctor/signature-input.tsx
+++ b/frontend/src/components/doctor/signature-input.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Pencil, Upload, X } from "lucide-react";
+import { useRef, useState, type ChangeEvent } from "react";
+
+import { Button } from "@/components/primitives/button";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { SignatureCanvas, type SignatureCanvasHandle } from "@/components/doctor/signature-canvas";
+
+// The saved e-signature shares the consultation signature's server policy:
+// PNG only, ≤ 200 KB. Uploads are validated here so the capture method
+// (upload vs draw) is interchangeable from the backend's point of view.
+const MAX_BYTES = 200 * 1024;
+
+type Mode = "upload" | "draw";
+
+// Optional saved-signature capture: upload a PNG or draw on a pad. Emits a
+// base64 data URL via onChange (or null when cleared). Reused by the doctor
+// registration form and the self-service profile page.
+export function SignatureInput({
+  value,
+  onChange,
+}: {
+  value: string | null;
+  onChange: (next: string | null) => void;
+}) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const padRef = useRef<SignatureCanvasHandle>(null);
+  const [mode, setMode] = useState<Mode>("draw");
+  const [error, setError] = useState<string | null>(null);
+  const [hasInk, setHasInk] = useState(false);
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file
+    if (!file) return;
+    setError(null);
+    if (file.type !== "image/png") {
+      setError("Use a PNG image (transparent background works best).");
+      return;
+    }
+    if (file.size > MAX_BYTES) {
+      setError("Signature must be under 200 KB.");
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = typeof reader.result === "string" ? reader.result : null;
+      if (result) onChange(result);
+    };
+    reader.onerror = () => setError("Couldn't read the file. Try again.");
+    reader.readAsDataURL(file);
+  };
+
+  const captureDrawing = () => {
+    const url = padRef.current?.toDataURL() ?? null;
+    if (!url) {
+      setError("Draw your signature first.");
+      return;
+    }
+    setError(null);
+    onChange(url);
+  };
+
+  if (value) {
+    return (
+      <div className="flex flex-col gap-3">
+        <div className="flex items-center gap-4 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+          <div className="flex h-20 w-40 shrink-0 items-center justify-center overflow-hidden rounded-lg border border-[var(--border)] bg-white">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={value} alt="Saved e-signature preview" className="max-h-full max-w-full object-contain" />
+          </div>
+          <div className="flex-1">
+            <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-emerald-600">
+              Signature ready
+            </div>
+            <p className="mt-1 text-sm text-[var(--muted-foreground)]">
+              Applied automatically when you finalise a consultation.
+            </p>
+          </div>
+          <Button type="button" variant="ghost" size="sm" onClick={() => onChange(null)}>
+            <X className="h-3.5 w-3.5" />
+            Clear
+          </Button>
+        </div>
+        {error && <ErrorBanner>{error}</ErrorBanner>}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="inline-flex w-fit gap-1 rounded-xl border border-[var(--border)] bg-[var(--muted)]/30 p-1">
+        <ToggleButton Icon={Pencil} label="Draw" selected={mode === "draw"} onClick={() => setMode("draw")} />
+        <ToggleButton Icon={Upload} label="Upload" selected={mode === "upload"} onClick={() => setMode("upload")} />
+      </div>
+
+      {mode === "draw" ? (
+        <div className="flex flex-col gap-2">
+          <SignatureCanvas ref={padRef} onChange={setHasInk} />
+          <div className="flex justify-end">
+            <Button type="button" size="sm" variant="secondary" disabled={!hasInk} onClick={captureDrawing}>
+              Use this signature
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <button
+          type="button"
+          onClick={() => inputRef.current?.click()}
+          className="group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/30 px-6 py-10 transition-colors hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]"
+        >
+          <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-3 text-white shadow-accent transition-transform duration-300 group-hover:scale-110">
+            <Upload className="h-5 w-5" />
+          </div>
+          <div className="text-center">
+            <div className="text-sm font-semibold tracking-[-0.01em]">Upload signature</div>
+            <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+              PNG · &lt; 200 KB · transparent background recommended
+            </div>
+          </div>
+        </button>
+      )}
+
+      <input ref={inputRef} type="file" accept="image/png" onChange={handleFile} className="sr-only" />
+      {error && <ErrorBanner>{error}</ErrorBanner>}
+    </div>
+  );
+}
+
+function ToggleButton({
+  Icon,
+  label,
+  selected,
+  onClick,
+}: {
+  Icon: typeof Pencil;
+  label: string;
+  selected: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={selected}
+      className={`inline-flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
+        selected
+          ? "bg-[var(--card)] text-[var(--foreground)] shadow-sm"
+          : "text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+      }`}
+    >
+      <Icon className="h-3.5 w-3.5" />
+      {label}
+    </button>
+  );
+}

--- a/frontend/src/components/doctor/signature-input.tsx
+++ b/frontend/src/components/doctor/signature-input.tsx
@@ -5,12 +5,23 @@ import { useRef, useState, type ChangeEvent } from "react";
 
 import { Button } from "@/components/primitives/button";
 import { ErrorBanner } from "@/components/primitives/error-banner";
+import { Modal } from "@/components/primitives/modal";
+import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
 import { SignatureCanvas, type SignatureCanvasHandle } from "@/components/doctor/signature-canvas";
 
-// The saved e-signature shares the consultation signature's server policy:
-// PNG only, ≤ 200 KB. Uploads are validated here so the capture method
-// (upload vs draw) is interchangeable from the backend's point of view.
-const MAX_BYTES = 200 * 1024;
+// Uploads accept PNG/JPEG (a photo of a signature is fine) — the editor crops
+// and removes the paper background, then re-encodes to PNG. Pre-edit budget is
+// generous; the FINAL PNG must satisfy the server policy (PNG, ≤ 200 KB).
+const ACCEPTED = ["image/png", "image/jpeg"];
+const MAX_INPUT_BYTES = 1_000_000;
+const MAX_OUTPUT_BYTES = 200 * 1024;
+
+// Approximate decoded byte size of a base64 data URL without allocating it.
+function dataUrlByteSize(dataUrl: string): number {
+  const base64 = dataUrl.includes(",") ? dataUrl.slice(dataUrl.indexOf(",") + 1) : dataUrl;
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
 
 type Mode = "upload" | "draw";
 
@@ -29,27 +40,41 @@ export function SignatureInput({
   const [mode, setMode] = useState<Mode>("draw");
   const [error, setError] = useState<string | null>(null);
   const [hasInk, setHasInk] = useState(false);
+  // The uploaded image being cropped / background-removed in the editor modal.
+  const [editorSource, setEditorSource] = useState<string | null>(null);
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     e.target.value = ""; // allow re-picking the same file
     if (!file) return;
     setError(null);
-    if (file.type !== "image/png") {
-      setError("Use a PNG image (transparent background works best).");
+    if (!ACCEPTED.includes(file.type)) {
+      setError("Use a PNG or JPEG image.");
       return;
     }
-    if (file.size > MAX_BYTES) {
-      setError("Signature must be under 200 KB.");
+    if (file.size > MAX_INPUT_BYTES) {
+      setError("Image must be under 1 MB.");
       return;
     }
     const reader = new FileReader();
     reader.onload = () => {
       const result = typeof reader.result === "string" ? reader.result : null;
-      if (result) onChange(result);
+      if (result) setEditorSource(result); // open the crop / remove-bg editor
     };
     reader.onerror = () => setError("Couldn't read the file. Try again.");
     reader.readAsDataURL(file);
+  };
+
+  // Editor "Apply" — accept the cropped PNG only if it fits the server cap,
+  // otherwise keep the editor open and nudge the doctor to crop tighter.
+  const acceptEdited = (next: string) => {
+    if (dataUrlByteSize(next) > MAX_OUTPUT_BYTES) {
+      setError("Cropped signature is over 200 KB — crop tighter or remove the background.");
+      return;
+    }
+    setError(null);
+    setEditorSource(null);
+    onChange(next);
   };
 
   const captureDrawing = () => {
@@ -116,14 +141,30 @@ export function SignatureInput({
           <div className="text-center">
             <div className="text-sm font-semibold tracking-[-0.01em]">Upload signature</div>
             <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
-              PNG · &lt; 200 KB · transparent background recommended
+              PNG or JPEG · crop &amp; remove background after upload
             </div>
           </div>
         </button>
       )}
 
-      <input ref={inputRef} type="file" accept="image/png" onChange={handleFile} className="sr-only" />
+      <input ref={inputRef} type="file" accept={ACCEPTED.join(",")} onChange={handleFile} className="sr-only" />
       {error && <ErrorBanner>{error}</ErrorBanner>}
+
+      <Modal
+        open={!!editorSource}
+        onClose={() => setEditorSource(null)}
+        title="Edit signature"
+        className="max-w-3xl"
+      >
+        {editorSource && (
+          <RubberStampEditor
+            source={editorSource}
+            description="Crop tightly around your signature. Remove the white paper background so it lays cleanly on the prescription."
+            onCancel={() => setEditorSource(null)}
+            onSave={acceptEdited}
+          />
+        )}
+      </Modal>
     </div>
   );
 }

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -566,6 +566,10 @@ export function useCurrentDoctor() {
 // A cache-busting param is the caller's job after a replace.
 export const MY_SIGNATURE_URL = `${API_URL}/doctors/me/signature`;
 
+// Same, for the calling doctor's rubber stamp image. Streamed rather than
+// inlined into /doctors/me so the doctor's every-page profile fetch stays lean.
+export const MY_STAMP_URL = `${API_URL}/doctors/me/stamp`;
+
 export type DoctorSelfUpdateRequest = {
   contact?: string;
   qualifications?: string;

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -232,8 +232,12 @@ export type DoctorCreateRequest = {
   qualifications: string;
   practitionerAddress: string;
   instituteName: string;
-  instituteContact: string;
+  // Institute phone is optional.
+  instituteContact?: string;
   rubberStampImage: string; // base64 (data: URL prefix accepted by backend)
+  // Optional saved e-signature, base64 data URL. Lets the doctor skip
+  // drawing a signature on every consultation.
+  defaultSignatureImage?: string;
 };
 
 export function useCreateDoctor() {
@@ -536,14 +540,52 @@ export function useSubmitConsultation(consultationId: number) {
   });
 }
 
-// Resolve the current doctor's row by matching JWT username — backend
-// availability endpoints take a doctor_id in the path, so the doctor's own
-// pages need this lookup. Reuses the standard /doctors list (cached).
+// The calling doctor's own profile, straight from GET /doctors/me. Backend
+// availability endpoints take a doctor_id in the path, and the consultation
+// flow needs hasDefaultSignature, so the doctor's own pages lean on this.
+// Only enabled for doctor sessions (the endpoint is doctor-only).
 export function useCurrentDoctor() {
   const { session } = useAuth();
-  const list = useDoctorList();
-  const doctor = list.data?.find((d) => d.username === session?.username) ?? null;
-  return { doctor, isLoading: list.isLoading, error: list.error };
+  const fetcher = useAuthedApi();
+  const query = useQuery({
+    queryKey: ["doctors", "me"],
+    queryFn: () => fetcher<Doctor>("/doctors/me"),
+    enabled: session?.role === "doctor",
+  });
+  return {
+    doctor: query.data ?? null,
+    hasDefaultSignature: query.data?.hasDefaultSignature ?? false,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+}
+
+// Absolute URL streaming the calling doctor's saved e-signature PNG. Used as
+// an <img src>; the cookie is sent automatically (same-origin / credentials).
+// A cache-busting param is the caller's job after a replace.
+export const MY_SIGNATURE_URL = `${API_URL}/doctors/me/signature`;
+
+export type DoctorSelfUpdateRequest = {
+  contact?: string;
+  qualifications?: string;
+  practitionerAddress?: string;
+  instituteName?: string;
+  instituteContact?: string;
+  rubberStampImage?: string;
+  defaultSignatureImage?: string;
+  clearDefaultSignature?: boolean;
+};
+
+// Doctor self-service profile edit (PATCH /doctors/me). Invalidates the
+// cached "me" profile (and the doctor list, which the admin views share).
+export function useUpdateMyProfile() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<Doctor, ApiError, DoctorSelfUpdateRequest>({
+    mutationFn: (body) => fetcher("/doctors/me", { method: "PATCH", body }),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["doctors"] }),
+  });
 }
 
 // ── Doctor availability ──────────────────────────────────────────────

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -73,7 +73,12 @@ export type Doctor = {
   qualifications: string;
   practitionerAddress: string;
   instituteName: string;
-  instituteContact: string;
+  // Institute phone is optional — null when the doctor didn't provide one.
+  instituteContact: string | null;
+  // True when the doctor has saved a default e-signature (lets them finalise
+  // consultations without drawing one each time). The image itself is fetched
+  // separately from GET /doctors/me/signature, never inlined here.
+  hasDefaultSignature?: boolean;
   active: boolean;
   // Four-state lifecycle (server-computed):
   //   awaiting_setup    → live unconsumed invite, no form submission yet
@@ -533,7 +538,9 @@ export type AppointmentCancelResponse = {
 
 // ── Submit consultation ──────────────────────────────────────────────
 export type SubmitConsultationRequest = {
-  signature: string;
+  // Optional: omit to finalise with the doctor's saved default e-signature.
+  // Required only when the doctor has no saved signature.
+  signature?: string;
   followUp?: FollowUpInput;
 };
 


### PR DESCRIPTION
## Summary

Doctors can optionally save a **default e-signature** once and have it applied automatically to every consultation, so they no longer have to draw a signature each time. Adds a doctor **self-service profile** page to manage it (and other practice details), and makes the **institute phone optional**.

## What changed

**Data model** (`Doctor`, Alembic `0016`, chained onto `0015_capture_sessions`)
- New nullable `default_signature_key` (S3 key for the saved e-signature; distinct from the rubber stamp)
- `institute_contact` relaxed to nullable

**Backend**
- `GET/PATCH /doctors/me` + `GET /doctors/me/signature` + `GET /doctors/me/stamp` — doctor self-service (doctor-only authz). Streams images rather than inlining them so `/me` stays lean.
- Registration + self-onboarding accept an optional `defaultSignatureImage`; `instituteContact` dropped from required fields.
- Consultation submit: `signature` is now optional. When omitted, the doctor's saved signature **bytes are copied** into a fresh per-consultation object — so changing the saved signature later never mutates an already-signed consultation (legal/audit immutability). `422 signature_required` when omitted and no default exists.

**Frontend**
- New `SignatureInput` (draw on a pad **or** upload PNG/JPEG, with the same crop / rotate / white-background-removal editor as the rubber stamp).
- Doctor form: e-signature capture + institute phone optional.
- New `/doctor/profile` page (+ nav entry): read-only identity, editable practice details, rubber stamp, and saved e-signature (set/replace/clear). Existing stamp/signature shown from the streamed endpoints.
- Consultation review: auto-applies the saved signature with a "draw a one-off signature instead" override.

## Editable vs locked
Doctors self-edit: contact, qualifications, practitioner address, institute name/phone, rubber stamp, e-signature. Locked (admin-only): name, email, SLMC number, username, approval lifecycle.

## Test plan
- [x] Backend integration suite (real Postgres + S3): **141 passed**, incl. authz, optional institute phone, registration/onboarding with & without e-signature, `/doctors/me` CRUD, signature & stamp streams, consultation default-signature submit, and the **immutability** guarantee.
- [x] Frontend `tsc --noEmit` clean; production build OK (`/doctor/profile` emitted).
- [x] Live end-to-end against the running Docker stack (create doctor w/ e-signature & no institute phone → doctor login → `/me`, `/me/signature`, `/me/stamp` → patch/clear/re-set → authz 403 → email locked). All green.
- [ ] Reviewer: manual click-through of the consultation review step (saved-signature path vs one-off draw).

🤖 Generated with [Claude Code](https://claude.com/claude-code)