### PR TITLE
fix: consultation Sign & submit dead-locks + start-meeting stranding appointments

### DIFF
--- a/backend/app/routers/preconsult.py
+++ b/backend/app/routers/preconsult.py
@@ -213,12 +213,17 @@ def start_meeting(
     appt = _appt(db, appt_id)
     if appt.status != "data_collection":
         raise conflict("invalid_state", currentStatus=appt.status)
+    # Mint the token BEFORE committing the transition: if LiveKit is down or
+    # unconfigured this raises, and the appointment must stay in
+    # data_collection so the healthworker can retry. Committing first left it
+    # stranded in_progress with no meeting and every retry 409ing.
+    token_payload = _hw_token_for(db, appt, user)
     appt.status = "in_progress"
     db.commit()
     db.refresh(appt)
     return {
         "appointment": AppointmentOut.model_validate(appt).model_dump(),
-        **_hw_token_for(db, appt, user),
+        **token_payload,
     }
 
 

--- a/backend/tests/test_start_meeting_atomicity.py
+++ b/backend/tests/test_start_meeting_atomicity.py
@@ -1,0 +1,102 @@
+"""Regression: a failed LiveKit token mint must not strand the appointment.
+
+start-meeting used to commit data_collection → in_progress BEFORE minting the
+LiveKit token. With LiveKit unconfigured (or unreachable) the mint raised 422,
+but the already-committed transition survived — so every retry 409'd with
+invalid_state and the meeting could never be started for that appointment.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+@pytest.fixture
+def hw_client(client, healthworker_account):
+    """TestClient already logged in as the healthworker."""
+    username, password = healthworker_account
+    r = client.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return client
+
+
+@pytest.fixture
+def data_collection_appointment(seeded_doctor):
+    """A patient + appointment sitting in data_collection, ready to start."""
+    from app.database import SessionLocal
+    from app.models import Appointment, Patient
+
+    db = SessionLocal()
+    try:
+        patient = Patient(given_name="Test", family_name="Patient", gender="female")
+        db.add(patient)
+        db.flush()
+        appt = Appointment(
+            patient_id=patient.patient_id,
+            doctor_id=seeded_doctor.doctor_id,
+            scheduled_at=datetime.now(timezone.utc) + timedelta(hours=1),
+            status="data_collection",
+        )
+        db.add(appt)
+        db.commit()
+        return appt.appointment_id
+    finally:
+        db.close()
+
+
+def _appt_status(appt_id: int) -> str:
+    from app.database import SessionLocal
+    from app.models import Appointment
+
+    db = SessionLocal()
+    try:
+        return db.get(Appointment, appt_id).status
+    finally:
+        db.close()
+
+
+def _set_livekit(monkeypatch, url: str, key: str, secret: str) -> None:
+    from app.config import settings
+
+    monkeypatch.setattr(settings, "LIVEKIT_URL", url)
+    monkeypatch.setattr(settings, "LIVEKIT_API_KEY", key)
+    monkeypatch.setattr(settings, "LIVEKIT_API_SECRET", secret)
+
+
+def test_failed_token_mint_leaves_appointment_retryable(
+    hw_client, data_collection_appointment, monkeypatch
+):
+    appt_id = data_collection_appointment
+
+    # LiveKit unconfigured → the mint inside start-meeting raises 422 ...
+    _set_livekit(monkeypatch, "", "", "")
+    r = hw_client.post(f"/appointments/{appt_id}/start-meeting", headers=_csrf(hw_client))
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["error"] == "livekit_not_configured"
+
+    # ... and the appointment must still be in data_collection, not stranded
+    # in_progress with no meeting.
+    assert _appt_status(appt_id) == "data_collection"
+
+    # With LiveKit configured (mint_token signs the JWT locally — no server
+    # involved), the retry succeeds and only now flips the status.
+    _set_livekit(
+        monkeypatch,
+        "wss://livekit.test.example",
+        "test_api_key",
+        "test_api_secret_at_least_32_chars_long",
+    )
+    r = hw_client.post(f"/appointments/{appt_id}/start-meeting", headers=_csrf(hw_client))
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["appointment"]["status"] == "in_progress"
+    assert body["room"] == f"appt-{appt_id}"
+    assert body["token"]
+    assert _appt_status(appt_id) == "in_progress"

--- a/frontend/src/app/(app)/doctor/consultations/[id]/page.tsx
+++ b/frontend/src/app/(app)/doctor/consultations/[id]/page.tsx
@@ -19,7 +19,11 @@ export default function ConsultationPage() {
   // Pull appointment via the consultation's appointmentId once we have it.
   const apt = useAppointment(consult.data?.appointmentId ?? null);
 
-  if (consult.error) {
+  // Hard-fail only when there's nothing to show. The consultation query
+  // refetches on every window focus (staleTime 0), so a transient refetch
+  // error with cached data present must NOT unmount the flow — that would
+  // wipe the doctor's stage, signature, and follow-up choice mid-consult.
+  if (consult.error && !consult.data) {
     return (
       <div className="mx-auto max-w-5xl px-6 py-12">
         <ErrorBanner>{explainError(consult.error.error)}</ErrorBanner>

--- a/frontend/src/components/doctor/consultation-flow.tsx
+++ b/frontend/src/components/doctor/consultation-flow.tsx
@@ -94,6 +94,20 @@ function defaultsFrom(c: Consultation): ConsultationFormShape {
   };
 }
 
+// A row the doctor added but never typed into. toPatch strips these on save,
+// so they must not block submission either — only a row with *some* content
+// but no generic name is genuinely incomplete.
+function medRowEmpty(m: ConsultationFormShape["medications"][number]) {
+  return (
+    !m.genericName.trim() &&
+    !m.tradeName?.trim() &&
+    !m.dose?.trim() &&
+    !m.frequency?.trim() &&
+    !m.duration?.trim() &&
+    !m.instructions?.trim()
+  );
+}
+
 // Strip empty entries before sending — the API tolerates them but the audit
 // trail looks cleaner with only non-empty rows.
 function toPatch(v: ConsultationFormShape) {
@@ -167,16 +181,20 @@ export function ConsultationFlow({
   const values = form.watch();
 
   // Save when leaving stage 1 or stage 2 — keeps drafts coherent if the
-  // doctor closes the tab between sections.
+  // doctor closes the tab between sections. Never throws: a failed save is
+  // surfaced via the update.error banner, so callers just check the result.
   const persist = async () => {
-    const v = form.getValues();
-    await update.mutateAsync(toPatch(v));
-    setSavedAt(new Date().toISOString());
+    try {
+      await update.mutateAsync(toPatch(form.getValues()));
+      setSavedAt(new Date().toISOString());
+      return true;
+    } catch {
+      return false;
+    }
   };
 
   const next = async () => {
-    await persist();
-    setStage(stage === "notes" ? "rx" : "review");
+    if (await persist()) setStage(stage === "notes" ? "rx" : "review");
   };
 
   const back = () => setStage(stage === "review" ? "rx" : "notes");
@@ -187,11 +205,17 @@ export function ConsultationFlow({
     let signature: string | undefined;
     if (drawingSignature) {
       const sig = sigRef.current?.toDataURL();
-      if (!sig) return;
+      if (!sig) {
+        // The canvas remounted blank (e.g. Back → Review) while `signed` went
+        // stale — resync so the button disables and shows its reason instead
+        // of swallowing the click.
+        setSigned(false);
+        return;
+      }
       signature = sig;
     }
     // Final patch in case anything's dirty since the last save.
-    await update.mutateAsync(toPatch(form.getValues()));
+    if (!(await persist())) return;
     let followUp: FollowUpInput | undefined;
     if (followUpChoice === "appointment" && followUpAt) {
       followUp = { kind: "appointment", scheduledAt: appLocalToUtcIso(followUpAt) };
@@ -206,17 +230,37 @@ export function ConsultationFlow({
     );
   };
 
-  // The submit button is disabled if the chosen branch is incomplete.
-  const followUpReady =
-    followUpChoice === "none" ||
-    (followUpChoice === "appointment" && followUpAt.length > 0) ||
-    (followUpChoice === "weeks" && followUpWeeks >= 1 && followUpWeeks <= 52);
-
-  // Validate medications client-side — every entry must have a non-empty
+  // Validate medications client-side — every non-empty entry must have a
   // genericName before we'll let the doctor submit. (Server enforces too.)
+  // Untouched empty rows don't count: toPatch strips them on save anyway.
   const medsValid = useMemo(
-    () => values.medications.every((m) => m.genericName.trim().length > 0),
+    () => values.medications.every((m) => m.genericName.trim().length > 0 || medRowEmpty(m)),
     [values.medications],
+  );
+
+  // Everything still blocking the submit, in plain words — rendered next to
+  // the disabled button so a blocked submit is never a mystery.
+  const submitBlockers: string[] = [];
+  if (!medsValid) submitBlockers.push("every medication needs a generic name");
+  if (followUpChoice === "appointment" && followUpAt.length === 0)
+    submitBlockers.push("pick the follow-up slot");
+  if (followUpChoice === "weeks" && !(followUpWeeks >= 1 && followUpWeeks <= 52))
+    submitBlockers.push("follow-up weeks must be 1–52");
+  if (drawingSignature && !signed) submitBlockers.push("sign in the box above");
+
+  // The review shows exactly what will be submitted — mirror toPatch's
+  // filtering so an untouched empty row doesn't render as a warning.
+  const reviewValues = useMemo(
+    () => ({
+      notes: values.notes,
+      diagnoses: values.diagnoses.filter((d) => d.code),
+      medications: values.medications.filter((m) => !medRowEmpty(m)),
+      labs: values.labs.filter((l) => l.testName?.trim() || l.instructions?.trim()),
+      referrals: values.referrals.filter(
+        (r) => r.specialistOrDepartment?.trim() || r.instructions?.trim(),
+      ),
+    }),
+    [values],
   );
 
   // Read-only path: a completed consultation is shown via the same component
@@ -226,7 +270,7 @@ export function ConsultationFlow({
       <Card className="p-8">
         <CompletedNotice signedAt={consultation.signedAt} />
         <div className="mt-6">
-          <ConsultationReview values={values} />
+          <ConsultationReview values={reviewValues} />
         </div>
       </Card>
     );
@@ -237,13 +281,6 @@ export function ConsultationFlow({
       <Card className="p-6">
         <ConsultationStepper current={stage} />
       </Card>
-
-      {update.error && (
-        <ErrorBanner>{explainError(update.error.error)}</ErrorBanner>
-      )}
-      {submit.error && (
-        <ErrorBanner>{explainError(submit.error.error)}</ErrorBanner>
-      )}
 
       <form onSubmit={(e) => e.preventDefault()} className="flex flex-col gap-8">
         {stage === "notes" && (
@@ -278,7 +315,7 @@ export function ConsultationFlow({
 
         {stage === "review" && (
           <div className="flex flex-col gap-6">
-            <ConsultationReview values={values} />
+            <ConsultationReview values={reviewValues} />
 
             <Card variant="elevated" className="flex flex-col gap-6 p-8">
               <div className="flex flex-col gap-3">
@@ -398,47 +435,65 @@ export function ConsultationFlow({
           </div>
         )}
 
+        {/* Errors render here, next to the buttons that caused them — the
+            footer is sticky at the bottom, so a banner at the top of the page
+            would sit outside the viewport and a failed click would look like
+            a dead button. */}
+        {update.error && (
+          <ErrorBanner>{explainError(update.error.error)}</ErrorBanner>
+        )}
+        {submit.error && (
+          <ErrorBanner>{explainError(submit.error.error)}</ErrorBanner>
+        )}
+
         {/* Footer — back / save / next / submit */}
-        <div className="sticky bottom-4 z-10 flex items-center justify-between gap-3 rounded-2xl border border-[var(--border)] bg-[var(--card)]/95 p-4 shadow-lg backdrop-blur">
-          <div className="flex items-center gap-2">
-            {stage !== "notes" && (
-              <Button type="button" variant="secondary" onClick={back}>
-                <ArrowLeft className="h-4 w-4" />
-                Back
-              </Button>
-            )}
-            <Button
-              type="button"
-              variant="ghost"
-              onClick={() => persist()}
-              disabled={update.isPending}
-            >
-              <Save className="h-4 w-4" />
-              {update.isPending ? "Saving…" : "Save draft"}
-            </Button>
-            {savedAt && !update.isPending && (
-              <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-600">
-                Saved {fmtRelative(savedAt)}
-              </span>
-            )}
-          </div>
-          <div>
-            {stage !== "review" && (
-              <Button type="button" onClick={next} disabled={update.isPending}>
-                {update.isPending ? "Saving…" : "Save & continue"}
-                <ArrowRight className="h-4 w-4" />
-              </Button>
-            )}
-            {stage === "review" && (
+        <div className="sticky bottom-4 z-10 flex flex-col gap-2 rounded-2xl border border-[var(--border)] bg-[var(--card)]/95 p-4 shadow-lg backdrop-blur">
+          {stage === "review" && submitBlockers.length > 0 && (
+            <p className="text-right text-xs font-medium text-amber-600">
+              To submit: {submitBlockers.join(" · ")}
+            </p>
+          )}
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              {stage !== "notes" && (
+                <Button type="button" variant="secondary" onClick={back}>
+                  <ArrowLeft className="h-4 w-4" />
+                  Back
+                </Button>
+              )}
               <Button
                 type="button"
-                onClick={onSubmit}
-                disabled={(drawingSignature && !signed) || !medsValid || !followUpReady || submit.isPending}
+                variant="ghost"
+                onClick={() => persist()}
+                disabled={update.isPending}
               >
-                <FileSignature className="h-4 w-4" />
-                {submit.isPending ? "Submitting…" : "Sign & submit"}
+                <Save className="h-4 w-4" />
+                {update.isPending ? "Saving…" : "Save draft"}
               </Button>
-            )}
+              {savedAt && !update.isPending && (
+                <span className="font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-600">
+                  Saved {fmtRelative(savedAt)}
+                </span>
+              )}
+            </div>
+            <div>
+              {stage !== "review" && (
+                <Button type="button" onClick={next} disabled={update.isPending}>
+                  {update.isPending ? "Saving…" : "Save & continue"}
+                  <ArrowRight className="h-4 w-4" />
+                </Button>
+              )}
+              {stage === "review" && (
+                <Button
+                  type="button"
+                  onClick={onSubmit}
+                  disabled={submitBlockers.length > 0 || submit.isPending}
+                >
+                  <FileSignature className="h-4 w-4" />
+                  {submit.isPending ? "Submitting…" : "Sign & submit"}
+                </Button>
+              )}
+            </div>
           </div>
         </div>
       </form>

--- a/frontend/src/components/doctor/signature-canvas.tsx
+++ b/frontend/src/components/doctor/signature-canvas.tsx
@@ -29,6 +29,15 @@ export const SignatureCanvas = forwardRef<
   const drawingRef = useRef(false);
   const [hasInk, setHasInk] = useState(false);
 
+  // A freshly mounted canvas is always blank — tell the parent immediately so
+  // a `signed` flag from a previous mount (e.g. Review → Back → Review, which
+  // remounts this component and discards the ink) can't go stale and leave
+  // the submit button enabled with nothing to submit.
+  useEffect(() => {
+    onChange?.(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
   // Set up the canvas at the device pixel ratio so strokes stay crisp on retina.
   useEffect(() => {
     const canvas = canvasRef.current!;

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -8,6 +8,7 @@ const MESSAGES: Record<string, string> = {
   session_consent_required: "Patient session consent is required first.",
   doctor_slot_taken: "That doctor already has another appointment at this time. Pick a different slot.",
   invalid_state: "This action isn't valid for the current appointment status.",
+  livekit_not_configured: "Video calling isn't configured on this server — contact your administrator. The appointment is unaffected; retry once it's fixed.",
   consultation_locked: "This consultation has been signed and locked — no further edits.",
   preconsult_locked: "Preconsult is locked — the meeting has already started.",
   consultation_not_ready: "The consultation isn't complete yet — the prescription PDF isn't available.",


### PR DESCRIPTION
## Problem

Two related "the button doesn't work" bugs around the consultation flow:

1. **Doctor side:** on the Review & sign page, the **Sign & submit** button was sometimes disabled (or enabled but inert) with no explanation. Root causes were all client-side gating, not call/meeting state:
   - An untouched empty medication row failed `medsValid`, but `toPatch` strips those rows on save — so a reload "fixed" it, making the bug look intermittent.
   - The reasons for a blocked submit were invisible on the review stage (the meds warning only rendered on stage 2).
   - Review → Back → Review remounted the signature canvas (wiping the ink) while the parent's `signed` flag stayed `true`: the button looked enabled but the click was swallowed by a silent `if (!sig) return`.
   - A failed pre-submit PATCH rejected out of the click handler unhandled, and error banners rendered at the top of the page while the buttons sit in a sticky bottom footer.
   - A transient consultation refetch error (staleTime 0 + refetch-on-focus) unmounted the whole flow even with cached data, wiping stage, signature, and follow-up choice.

2. **Healthworker side:** `POST /appointments/{id}/start-meeting` committed `data_collection → in_progress` **before** minting the LiveKit token. If the mint raised (LiveKit unconfigured/unreachable), the 422 went out but the committed transition survived — every retry then 409'd `invalid_state` and the meeting could never be started for that appointment.

## Fix

**Frontend (`consultation-flow.tsx`, `signature-canvas.tsx`, consultation page):**
- Fully-empty medication rows no longer block submission (they're stripped on save anyway); only rows with content but no generic name do.
- The sticky footer now lists every unmet submit requirement next to the disabled button (e.g. "To submit: every medication needs a generic name · sign in the box above").
- `SignatureCanvas` notifies the parent on mount that it's blank, so a stale `signed` flag can't survive a remount; the submit guard resyncs instead of silently returning. (This also fixes the same stale-flag issue in the doctor-profile `signature-input` Draw/Upload toggle.)
- `persist()` no longer throws out of click handlers; error banners render beside the footer where the doctor is looking.
- The consultation page only hard-fails when there is no cached data, so a transient refetch error no longer unmounts the flow mid-consult.
- The review pane mirrors `toPatch`'s filtering, showing exactly what will be submitted.
- Friendly message for `livekit_not_configured`.

**Backend (`preconsult.py`):**
- `start_meeting` mints the token **before** committing the transition — a failed mint leaves the appointment in `data_collection` and the healthworker can simply retry.

## Notes

- The submit endpoint already accepts both `in_progress` and `awaiting_notes`, so no call-ending path (doctor, healthworker, or patient device) can block submission — verified, not changed.
- The backend reorder is happy-path identical: `mint_token` signs the JWT locally and only fails on misconfiguration.

## Testing

- New regression test `test_start_meeting_atomicity.py` — verified it fails on the old code and passes on the fix (422 with status still `data_collection`, then a successful retry).
- Full backend suite: 142 passed against real Postgres + rustfs.
- Frontend: `tsc --noEmit` clean, lint clean, production `next build` passes.
- Manually reproduced the original stranding via docker compose (422 → stuck `in_progress` → every retry 409) and confirmed the fixed image leaves the appointment retryable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)