### PR TITLE
ops(deployment): temporary SSH lockout diagnostics + perms enforcement

### DIFF
--- a/deployment/ansible/playbook.yml
+++ b/deployment/ansible/playbook.yml
@@ -32,6 +32,46 @@
         marker: "# {mark} ANSIBLE MANAGED — operator keys"
         block: '{{ operator_authorized_keys | join("\n") }}'
 
+    # ── TEMPORARY: SSH lockout investigation (remove once resolved) ──────────
+    # Operator keys are present in the managed block (the task above reports
+    # "ok") yet sshd refuses the key offer for at least one operator. Enforce
+    # the ownership/permissions sshd's StrictModes checks (no-ops when already
+    # correct), then dump the evidence into the CI log: file perms, the literal
+    # authorized_keys bytes (public keys only — safe to print), sshd's
+    # effective auth settings, and recent auth failures from the journal.
+    - name: Ensure admin home is not group/world-writable
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}"
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "g-w,o-w"
+
+    - name: Ensure .ssh directory ownership and mode
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/.ssh"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: "0700"
+
+    - name: Collect SSH diagnostics
+      ansible.builtin.shell: |
+        echo '== home/.ssh/authorized_keys perms =='
+        ls -ld /home/{{ ansible_user }} /home/{{ ansible_user }}/.ssh /home/{{ ansible_user }}/.ssh/authorized_keys
+        echo '== authorized_keys content (cat -A shows invisible chars) =='
+        cat -A /home/{{ ansible_user }}/.ssh/authorized_keys
+        echo '== sshd effective auth config =='
+        /usr/sbin/sshd -T 2>/dev/null | grep -iE 'authorizedkeysfile|pubkeyauthentication|pubkeyaccepted|strictmodes|allowusers|allowgroups|denyusers|maxauthtries' || true
+        echo '== recent sshd auth log (source IPs redacted — public repo, public logs) =='
+        journalctl -u ssh -u sshd -n 300 --no-pager | grep -iE 'denied|invalid|error|fail|refus|userauth|authentication' | tail -40 | sed -E 's/([0-9]{1,3}\.){3}[0-9]{1,3}/REDACTED-IP/g' || true
+      register: ssh_diag
+      changed_when: false
+
+    - name: Show SSH diagnostics
+      ansible.builtin.debug:
+        msg: "{{ ssh_diag.stdout_lines }}"
+    # ── END TEMPORARY ────────────────────────────────────────────────────────
+
     # The apt module needs python3-apt, which minimal Debian 12 cloud images may
     # lack. raw uses /bin/sh (no python deps) to bootstrap it before any apt task.
     - name: Bootstrap python3-apt


### PR DESCRIPTION
## Why

Operator SSH key auth is refused on the VM even though the Ansible-managed block in `authorized_keys` reports `ok` on every deploy (verified against run 27251767613). All operator-side factors check out — the offered key fingerprint matches the configured key exactly — so the cause is server-side and we need eyes on the VM without interactive SSH access.

## What

Ansible playbook only — Terraform does not read this file (branch `intent=plan` dry-run: run 27321477897, no instance changes).

- Enforce ownership/mode on `/home/admin` and `/home/admin/.ssh` (the conditions sshd's StrictModes silently rejects keys over). No-ops when already correct.
- Dump diagnostics into the CI log: file perms, literal `authorized_keys` bytes (`cat -A`; public keys only — already published in this repo's `group_vars/all.yml`), sshd's effective auth settings, and recent auth-failure journal lines with **source IPs redacted** (public repo → public logs).

## Temporary

Marked TEMPORARY in the playbook; will be reverted once the lockout is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)