### PR TITLE
ops(deployment): reconcile tfvars image pin to 0.5.1

### DIFF
--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -13,5 +13,5 @@
 # NOTE: the referenced tag must already exist in GHCR before you apply, or the
 # Ansible `docker compose pull` step fails. For a new semver, push the git tag and
 # wait for the "Build Docker images" workflow to go green first.
-docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.1.0"
-docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.1.0"
+docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.5.1"
+docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.5.1"


### PR DESCRIPTION
## Why

Prod runs **0.5.0** via the deploy workflow's ephemeral `image_tag` override (run 27251767613), but `terraform.tfvars` still pins **0.1.0**. The override note in deploy.yml requires reconciling tfvars after use — that never happened, so any blank-tag apply would silently **downgrade prod by four releases** against a database that's already migrated past them.

## What

Pin both images to **0.5.1** — the latest release; its images were published by the green tag build on 2026-06-10 (after the 0.5.0 deploy).

## Effect on next apply (blank image_tag)

Containers are recreated with 0.5.1 — i.e. this rolls out the 0.5.0 → 0.5.1 upgrade (consultation submit gating fix etc.). No VM rebuild: image vars don't touch the instance (proven by yesterday's 0.5.0 rollout, which replaced nothing but the recurring `public_ports` quirk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)