### PR TITLE
fix(deployment): operator SSH keys collapsed onto one malformed line

### DIFF
--- a/deployment/ansible/playbook.yml
+++ b/deployment/ansible/playbook.yml
@@ -30,7 +30,14 @@
         group: "{{ ansible_user }}"
         mode: "0600"
         marker: "# {mark} ANSIBLE MANAGED — operator keys"
-        block: '{{ operator_authorized_keys | join("\n") }}'
+        # A for-loop, NOT `join("\n")`: ansible-core 2.19's templating engine
+        # stopped unescaping string constants, so join("\n") emits a literal
+        # backslash-n, collapsing every key onto one malformed line that sshd
+        # rejects wholesale (this locked all operators out).
+        block: |
+          {% for key in operator_authorized_keys %}
+          {{ key }}
+          {% endfor %}
 
     # ── TEMPORARY: SSH lockout investigation (remove once resolved) ──────────
     # Operator keys are present in the managed block (the task above reports


### PR DESCRIPTION
## Root cause (found via the #29 diagnostics, run 27321875413)

`cat -A` of `/home/admin/.ssh/authorized_keys` on the VM shows all five operator keys on **one line**, joined by literal `\n` characters:

```
ssh-ed25519 AAAA...qpMY\nssh-ed25519 AAAA...bfco\n...\nssh-ed25519 AAAA...dQ26X2$
```

ansible-core 2.19's new templating engine stopped unescaping string constants, so `join("\n")` in the blockinfile `block` emits a literal backslash-n. sshd rejects the malformed line wholesale → **every operator key is dead**; only the cloud-init bootstrap key (its own intact line) works. CI installs ansible-core fresh via pipx each run, which is how the regression arrived without any repo change.

Permissions/ownership were verified correct; not a factor.

## Fix

Render the block with a `{% for %}` loop — one key per line under any engine version. Verified locally against `trim_blocks=True` (Ansible's default). On next apply, blockinfile rewrites the managed block correctly (it will report `changed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)