### PR TITLE
fix: phone photo uploads + admin e-signature edit

### DIFF
--- a/backend/app/routers/doctor_onboarding.py
+++ b/backend/app/routers/doctor_onboarding.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastapi import APIRouter, Body, Depends, Response, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Response, status
 from sqlalchemy.orm import Session
 
 from ..deps import db_dep
@@ -121,6 +121,8 @@ def complete(
     submission = DoctorOnboardingSubmit.model_validate(payload)
     try:
         stamp_bytes = decode_rubber_stamp(submission.rubberStampImage)
+    except HTTPException:
+        raise  # let rubber_stamp_too_large / invalid_rubber_stamp_image propagate as-is
     except Exception as exc:
         raise unprocessable("invalid_rubber_stamp_image", detail=str(exc))
 

--- a/backend/app/routers/doctors.py
+++ b/backend/app/routers/doctors.py
@@ -766,13 +766,14 @@ def update_doctor(doctor_id: int, payload: DoctorUpdate, db: Session = Depends(d
     }
     data = payload.model_dump(exclude_unset=True)
 
-    superseded_key: str | None = None
+    superseded: list[str] = []
     if "rubberStampImage" in data and data["rubberStampImage"] is not None:
         stamp = decode_rubber_stamp(data.pop("rubberStampImage"))
         mime, ext = _sniff_stamp(stamp)
         new_key = object_key("doctors/stamps", ext)
         put_bytes(new_key, stamp, mime)
-        superseded_key = doctor.rubber_stamp_key
+        if doctor.rubber_stamp_key:
+            superseded.append(doctor.rubber_stamp_key)
         doctor.rubber_stamp_key = new_key
     else:
         data.pop("rubberStampImage", None)
@@ -784,6 +785,21 @@ def update_doctor(doctor_id: int, payload: DoctorUpdate, db: Session = Depends(d
     else:
         data.pop("password", None)
 
+    # clearDefaultSignature wins over a supplied image, same as update_me.
+    clear_sig = data.pop("clearDefaultSignature", False)
+    new_sig_image = data.pop("defaultSignatureImage", None)
+    if clear_sig:
+        if doctor.default_signature_key:
+            superseded.append(doctor.default_signature_key)
+        doctor.default_signature_key = None
+    elif new_sig_image:
+        sig = decode_signature(new_sig_image)
+        sig_key = object_key("doctors/signatures", "png")
+        put_bytes(sig_key, sig, "image/png")
+        if doctor.default_signature_key:
+            superseded.append(doctor.default_signature_key)
+        doctor.default_signature_key = sig_key
+
     for k, v in data.items():
         col = field_map.get(k)
         if col is not None:
@@ -791,10 +807,10 @@ def update_doctor(doctor_id: int, payload: DoctorUpdate, db: Session = Depends(d
 
     db.commit()
     db.refresh(doctor)
-    # Drop the superseded object only once the new key is committed — a failed
-    # commit rolls back to old_key, so we must not delete it pre-commit.
-    if superseded_key:
-        delete_object(superseded_key)
+    # Drop superseded objects only after the new keys are committed — a failed
+    # commit rolls back to old keys, so we must not delete them pre-commit.
+    for key in superseded:
+        delete_object(key)
     out = DoctorOut.model_validate(doctor)
     has_live = doctor.doctor_id in _doctors_with_live_invite(db, [doctor.doctor_id])
     return _attach_status(out, doctor, has_live_invite=has_live)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -160,6 +160,8 @@ class DoctorUpdate(BaseModel):
     instituteName: Optional[str] = None
     instituteContact: Optional[str] = None
     rubberStampImage: Optional[str] = None
+    defaultSignatureImage: Optional[str] = None
+    clearDefaultSignature: bool = False
     active: Optional[bool] = None
 
 

--- a/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
+++ b/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
@@ -320,6 +320,8 @@ export default function DoctorDetailPage() {
             };
             if (payload.password) body.password = payload.password;
             if (payload.rubberStampImage) body.rubberStampImage = payload.rubberStampImage;
+            if (payload.defaultSignatureImage) body.defaultSignatureImage = payload.defaultSignatureImage;
+            if (payload.clearDefaultSignature) body.clearDefaultSignature = true;
             update.mutate(body);
           }}
           onCancel={() => router.push("/admin")}

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -57,8 +57,9 @@ export type DoctorFormPayload = {
   instituteName: string;
   instituteContact?: string;
   rubberStampImage?: string; // base64 — required on create, optional on update
-  // base64 PNG saved e-signature — only captured on create / self-onboarding.
+  // base64 PNG saved e-signature — set to replace, clearDefaultSignature to remove.
   defaultSignatureImage?: string;
+  clearDefaultSignature?: boolean;
   username?: string; // create only
   password?: string;
 };
@@ -98,9 +99,13 @@ export function DoctorForm({
   const [stamp, setStamp] = useState<string | null>(initial?.rubberStampImage ?? null);
   const [stampDirty, setStampDirty] = useState(false);
   const [stampError, setStampError] = useState<string | null>(null);
-  // Optional saved e-signature, captured on create / self-onboarding only.
-  // null = none provided (the doctor will sign each consultation by hand).
+  // Saved e-signature state. On create, starts null. On update, we track:
+  //   - replacingSignature: true → SignatureInput shown to set a new one
+  //   - clearSignature: true → send clearDefaultSignature to the backend
+  //   - signature: non-null new image the doctor drew/uploaded this session
   const [signature, setSignature] = useState<string | null>(null);
+  const [clearSignature, setClearSignature] = useState(false);
+  const [replacingSignature, setReplacingSignature] = useState(false);
   // Onboarding-mode picker. "invite" (default) tells the backend to email
   // the doctor a link to set their own password. "manual" preserves the
   // legacy flow — admin types the password and shares it offline. Only
@@ -176,7 +181,6 @@ export function DoctorForm({
     };
     if (isCreate) {
       payload.username = v.username?.trim();
-      // Saved e-signature is optional and only captured on create paths.
       if (signature) payload.defaultSignatureImage = signature;
       if (isSelfOnboarding) {
         // Self-onboarding: password is always sent (validated above).
@@ -185,8 +189,14 @@ export function DoctorForm({
         payload.password = v.password;
       }
       // admin invite mode → payload.password stays undefined; backend fires invite
-    } else if (v.password && v.password.trim()) {
-      payload.password = v.password;
+    } else {
+      // Update mode — include signature changes if any.
+      if (clearSignature) {
+        payload.clearDefaultSignature = true;
+      } else if (signature) {
+        payload.defaultSignatureImage = signature;
+      }
+      if (v.password && v.password.trim()) payload.password = v.password;
     }
     onSubmit(payload);
   });
@@ -345,15 +355,56 @@ export function DoctorForm({
         {stampError && <p className="mt-2 text-xs text-rose-600">{stampError}</p>}
       </Section>
 
-      {isCreate && (
-        <Section
-          Icon={PenLine}
-          title="Default e-signature"
-          hint="Optional. Save a signature once and it's applied automatically on every consultation — no need to sign each time. You can still draw a one-off signature per consultation, and you can add or change this later from your profile."
-        >
-          <SignatureInput value={signature} onChange={setSignature} />
-        </Section>
-      )}
+      <Section
+        Icon={PenLine}
+        title="Default e-signature"
+        hint={isCreate
+          ? "Optional. Save a signature once and it's applied automatically on every consultation — no need to sign each time."
+          : "Replaces or removes the doctor's saved e-signature."}
+      >
+        {/* Update mode: show "on file" state with replace / clear actions */}
+        {!isCreate && (() => {
+          const hasOnFile = !!initial?.hasDefaultSignature;
+          const showOnFile = hasOnFile && !clearSignature && !replacingSignature && !signature;
+          if (showOnFile) {
+            return (
+              <div className="flex items-center gap-3 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+                <div className="flex-1">
+                  <div className="font-mono text-[10px] uppercase tracking-[0.15em] text-emerald-600">Signature on file</div>
+                  <p className="mt-1 text-sm text-[var(--muted-foreground)]">The doctor has a saved default e-signature.</p>
+                </div>
+                <button type="button" onClick={() => setReplacingSignature(true)}
+                  className="text-sm text-[var(--accent)] hover:underline">Replace</button>
+                <button type="button" onClick={() => setClearSignature(true)}
+                  className="text-sm text-rose-600 hover:underline">Remove</button>
+              </div>
+            );
+          }
+          if (clearSignature) {
+            return (
+              <div className="flex items-center gap-3 rounded-xl border border-rose-200 bg-rose-50 p-4">
+                <div className="flex-1 text-sm text-rose-700">Signature will be removed on save.</div>
+                <button type="button" onClick={() => setClearSignature(false)}
+                  className="text-sm text-[var(--accent)] hover:underline">Undo</button>
+              </div>
+            );
+          }
+          // replacingSignature=true or no prior signature — show the input
+          return (
+            <div className="flex flex-col gap-2">
+              <SignatureInput value={signature} onChange={setSignature} />
+              {(replacingSignature || !hasOnFile) && signature === null && (
+                <button type="button" onClick={() => { setReplacingSignature(false); setSignature(null); }}
+                  className="self-start text-xs text-[var(--muted-foreground)] hover:underline">
+                  {hasOnFile ? "Keep existing" : "Skip"}
+                </button>
+              )}
+            </div>
+          );
+        })()}
+        {/* Create mode: plain optional input */}
+        {isCreate && <SignatureInput value={signature} onChange={setSignature} />}
+      </Section>
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
         {onCancel && (

--- a/frontend/src/components/admin/rubber-stamp-editor.tsx
+++ b/frontend/src/components/admin/rubber-stamp-editor.tsx
@@ -14,12 +14,18 @@ export function RubberStampEditor({
   onCancel,
   onSave,
   description = "Crop the stamp tightly. Optionally remove the white paper background so it lays cleanly on the prescription.",
+  forcePng = false,
 }: {
   source: string;
   onCancel: () => void;
   onSave: (next: string) => void;
   // Overridable so the same editor reads correctly for signatures too.
   description?: string;
+  // When true the output is always PNG (required for signatures — the backend
+  // rejects JPEG for that asset type). Leave false for rubber stamps: the
+  // editor uses JPEG when no background has been removed (much smaller for
+  // phone photos) and PNG only when transparency is needed.
+  forcePng?: boolean;
 }) {
   const imgRef = useRef<HTMLImageElement>(null);
   const previewRef = useRef<HTMLCanvasElement>(null);
@@ -91,7 +97,13 @@ export function RubberStampEditor({
     if (!img || !completed) return;
     const out = document.createElement("canvas");
     drawProcessed(img, completed, removeBg, threshold, out);
-    onSave(out.toDataURL("image/png"));
+    // Use PNG when transparency is needed (background removed) or explicitly
+    // required by the caller (e.g. signature — backend only accepts PNG magic
+    // bytes). Fall back to JPEG for opaque stamps: a phone photo re-encoded
+    // as PNG can be 5–10× larger than the same image as a high-quality JPEG,
+    // which routinely causes the 1 MB server limit to be hit.
+    const mime = forcePng || removeBg ? "image/png" : "image/jpeg";
+    onSave(out.toDataURL(mime, mime === "image/jpeg" ? 0.92 : undefined));
   };
 
   return (

--- a/frontend/src/components/admin/rubber-stamp-uploader.tsx
+++ b/frontend/src/components/admin/rubber-stamp-uploader.tsx
@@ -10,8 +10,16 @@ import { Modal } from "@/components/primitives/modal";
 import { QrCaptureModal } from "@/components/primitives/qr-capture-modal";
 import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
 
-const MAX_BYTES = 1_000_000; // 1 MB — keeps the patient PDF lean
+const MAX_INPUT_BYTES = 1_000_000; // 1 MB input file limit
+const MAX_OUTPUT_BYTES = 1_000_000; // 1 MB — must match the backend rubber_stamp policy
 const ACCEPTED = ["image/png", "image/jpeg"];
+
+// Approximate decoded byte size of a base64 data URL without allocating it.
+function dataUrlByteSize(dataUrl: string): number {
+  const base64 = dataUrl.includes(",") ? dataUrl.slice(dataUrl.indexOf(",") + 1) : dataUrl;
+  const padding = base64.endsWith("==") ? 2 : base64.endsWith("=") ? 1 : 0;
+  return Math.floor((base64.length * 3) / 4) - padding;
+}
 
 // Reads a file → base64 data URL (`data:image/png;base64,…`). The backend
 // strips the data: prefix on its own, so either form is acceptable.
@@ -37,14 +45,14 @@ export function RubberStampUploader({
   const [qrOpen, setQrOpen] = useState(false);
 
   // Validate then read a file → base64 data URL → open the editor. Shared by
-  // the file picker and the camera capture.
+  // the file picker, camera capture, and QR relay.
   const processFile = (file: File) => {
     setError(null);
     if (!ACCEPTED.includes(file.type)) {
       setError("Use a PNG or JPEG.");
       return;
     }
-    if (file.size > MAX_BYTES) {
+    if (file.size > MAX_INPUT_BYTES) {
       setError("Image must be under 1 MB.");
       return;
     }
@@ -55,6 +63,19 @@ export function RubberStampUploader({
     };
     reader.onerror = () => setError("Couldn't read the file. Try again.");
     reader.readAsDataURL(file);
+  };
+
+  // Validate the editor output before committing it. Phone photos re-encoded
+  // as PNG can exceed the server's 1 MB limit — catch it here with a clear
+  // message rather than a server-side rejection after the whole form submits.
+  const acceptEdited = (next: string) => {
+    if (dataUrlByteSize(next) > MAX_OUTPUT_BYTES) {
+      setError("Stamp image is over 1 MB after processing — crop tighter or remove the background.");
+      return;
+    }
+    setError(null);
+    onChange(next);
+    setEditorSource(null);
   };
 
   const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
@@ -213,10 +234,7 @@ export function RubberStampUploader({
           <RubberStampEditor
             source={editorSource}
             onCancel={() => setEditorSource(null)}
-            onSave={(next) => {
-              onChange(next);
-              setEditorSource(null);
-            }}
+            onSave={acceptEdited}
           />
         )}
       </Modal>

--- a/frontend/src/components/doctor/signature-input.tsx
+++ b/frontend/src/components/doctor/signature-input.tsx
@@ -162,6 +162,7 @@ export function SignatureInput({
             description="Crop tightly around your signature. Remove the white paper background so it lays cleanly on the prescription."
             onCancel={() => setEditorSource(null)}
             onSave={acceptEdited}
+            forcePng
           />
         )}
       </Modal>

--- a/frontend/src/components/primitives/qr-capture-modal.tsx
+++ b/frontend/src/components/primitives/qr-capture-modal.tsx
@@ -134,6 +134,7 @@ export function QrCaptureModal({
           });
           if (!res.ok) {
             relayHandledRef.current = false;
+            setError("Couldn't retrieve the photo — try scanning the QR again.");
             return;
           }
           const blob = await res.blob();
@@ -144,6 +145,7 @@ export function QrCaptureModal({
           onClose();
         } catch {
           relayHandledRef.current = false;
+          setError("Couldn't retrieve the photo — check your connection and try again.");
         }
       })();
     }

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -94,6 +94,11 @@ const MESSAGES: Record<string, string> = {
   account_in_use:
     "This account has records attached to it and can't be deleted. Disable it instead to block sign-in while keeping its history.",
   request_failed: "Something went wrong. Try again.",
+  // Generic server-side errors — shown when the backend doesn't return a
+  // recognisable domain code (e.g. unhandled exception or schema mismatch).
+  internal_error: "Something went wrong on the server. Try again in a moment.",
+  validation_failed: "The form data couldn't be validated. Check your inputs and try again.",
+  forbidden: "You don't have permission to do that.",
 };
 
 export function explainError(code: string, fallback?: string): string {

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -250,7 +250,10 @@ export function useCreateDoctor() {
   });
 }
 
-export type DoctorUpdateRequest = Partial<DoctorCreateRequest> & { active?: boolean };
+export type DoctorUpdateRequest = Partial<DoctorCreateRequest> & {
+  active?: boolean;
+  clearDefaultSignature?: boolean;
+};
 
 export function useUpdateDoctor(id: number) {
   const fetcher = useAuthedApi();


### PR DESCRIPTION
## Summary

Two related fixes shipped together:

- **Phone photo uploads**: five bugs caused a generic "Something went wrong" whenever a phone photo was used as a rubber stamp or during doctor registration
- **Admin e-signature edit**: the admin doctor-edit page had no way to set, replace, or remove a doctor's saved e-signature — the feature existed on the doctor's own profile page but was completely absent from the admin flow

## Phone upload root causes

**1. Missing error codes** (`error-codes.ts`)
`internal_error`, `validation_failed`, and `forbidden` had no entries in the client error map, so any unhandled server exception fell through to the generic message.

**2. Editor always encoded PNG** (`rubber-stamp-editor.tsx`)
`toDataURL("image/png")` on a phone photo produces 5–10× larger output than JPEG. A 1280×960 photo trivially exceeds the 1 MB server limit. The editor now uses JPEG unless background removal is active (alpha required).

**3. No output size validation** (`rubber-stamp-uploader.tsx`)
The edited stamp went straight to the form store with no size check. A client-side 1 MB guard now mirrors the server policy and shows a clear message before submit.

**4. Onboarding swallowed specific stamp errors** (`doctor_onboarding.py`)
A broad `except Exception` around `decode_rubber_stamp()` re-raised `rubber_stamp_too_large` as the generic `invalid_rubber_stamp_image`. HTTPExceptions now propagate unchanged.

**5. Silent relay failure** (`qr-capture-modal.tsx`)
When the desktop failed to pull the parked phone photo, the modal reset silently — leaving "Waiting for the photo…" with no feedback. Both the non-OK path and the network exception path now surface an error message.

## E-signature admin edit

`DoctorUpdate` schema was missing `defaultSignatureImage` and `clearDefaultSignature`, so `update_doctor` had no way to touch a doctor's signature. Fixed:

- Schema: added both fields (mirrors `DoctorSelfUpdate`)
- `update_doctor`: signature replace/clear with superseded-key cleanup (mirrors `update_me`)
- `DoctorForm`: signature section now shown in update mode — "Signature on file" with Replace / Remove actions when one exists, plain input when none
- `admin/doctors/[id]/page.tsx`: passes the new fields through to the mutation
- `DoctorUpdateRequest`: added `clearDefaultSignature` to the TS type

## Test plan

- [ ] Phone photo for rubber stamp (doctor profile) → editor → Apply → saves without error
- [ ] Phone photo during doctor registration → editor → submit → works
- [ ] Large phone photo, no crop → editor shows "over 1 MB" before form submit
- [ ] Background removed → output still PNG (alpha preserved)
- [ ] QR relay failure → desktop shows error instead of infinite spinner
- [ ] Admin edits doctor with no signature → section shows input to add one
- [ ] Admin edits doctor with existing signature → shows "Signature on file" + Replace / Remove
- [ ] Admin removes signature → cleared on save
- [ ] Admin replaces signature → new one takes effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)