### PR TITLE
feat(sysadmin): editable clinic identity and system defaults

### DIFF
--- a/backend/app/routers/sysadmin.py
+++ b/backend/app/routers/sysadmin.py
@@ -16,6 +16,7 @@ which is admin-gated. The sys-admin may edit its OWN profile + password
 — that would be a lockout.
 """
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from fastapi import APIRouter, Depends, Response, status
 from pydantic import BaseModel, Field
@@ -32,10 +33,11 @@ from ..models import (
     Doctor,
     DoctorAvailability,
     QueueEntry,
+    SystemConfig,
 )
 from ..security import hash_password
 from ..services.passwords import validate_new_password
-from ..services.system_config import get_system_config
+from ..services.system_config import get_system_config, reload_system_config
 
 
 router = APIRouter(prefix="/sysadmin", tags=["sysadmin"])
@@ -74,6 +76,78 @@ def system_config(_: CurrentUser = Depends(require_role("sys-admin"))) -> dict:
         "appTimezone": cfg.app_timezone,
         "exportTimezone": cfg.export_timezone,
         "masterConsentVersion": cfg.master_consent_version,
+    }
+
+
+class SystemConfigUpdateIn(BaseModel):
+    # All fields are optional (PATCH semantics). Omitted = leave untouched;
+    # explicit null clears a nullable field to NULL.
+    instituteName: str | None = None
+    instituteAddressLines: list[str] | None = None
+    instituteContactPhone: str | None = None
+    instituteContactEmail: str | None = None
+    appTimezone: str | None = None
+    exportTimezone: str | None = None
+    masterConsentVersion: str | None = None
+
+
+def _valid_timezone(tz: str | None) -> bool:
+    if tz is None:
+        return True
+    try:
+        ZoneInfo(tz)
+        return True
+    except (ZoneInfoNotFoundError, KeyError):
+        return False
+
+
+@router.patch("/system-config")
+def update_system_config(
+    payload: SystemConfigUpdateIn,
+    db: Session = Depends(db_dep),
+    _: CurrentUser = Depends(require_role("sys-admin")),
+) -> dict:
+    """Edit the clinic / institute identity and system defaults. Reloads the
+    in-memory LiveConfig cache so runtime consumers (PDF, exports) see the
+    change immediately without a restart."""
+    row = db.get(SystemConfig, 1)
+    if row is None:
+        raise not_found("system_config_not_found")
+
+    fields = payload.model_dump(exclude_unset=True)
+
+    for tz_key in ("appTimezone", "exportTimezone"):
+        if tz_key in fields and not _valid_timezone(fields[tz_key]):
+            raise unprocessable("invalid_timezone")
+
+    if "instituteName" in fields:
+        row.institute_name = _clean(payload.instituteName)
+    if "instituteAddressLines" in fields:
+        row.institute_address_lines = payload.instituteAddressLines or None
+    if "instituteContactPhone" in fields:
+        row.institute_contact_phone = _clean(payload.instituteContactPhone)
+    if "instituteContactEmail" in fields:
+        row.institute_contact_email = _clean(payload.instituteContactEmail)
+    if "appTimezone" in fields:
+        row.app_timezone = payload.appTimezone
+    if "exportTimezone" in fields:
+        row.export_timezone = payload.exportTimezone
+    if "masterConsentVersion" in fields:
+        row.master_consent_version = _clean(payload.masterConsentVersion)
+
+    db.commit()
+    db.refresh(row)
+    reload_system_config(db)
+
+    return {
+        "initializedAt": row.initialized_at,
+        "instituteName": row.institute_name,
+        "instituteAddressLines": row.institute_address_lines,
+        "instituteContactPhone": row.institute_contact_phone,
+        "instituteContactEmail": row.institute_contact_email,
+        "appTimezone": row.app_timezone,
+        "exportTimezone": row.export_timezone,
+        "masterConsentVersion": row.master_consent_version,
     }
 
 

--- a/frontend/src/app/(app)/sysadmin/page.tsx
+++ b/frontend/src/app/(app)/sysadmin/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Building2, Clock, FileText, MapPin, Phone, Mail, ShieldCheck, UserCog } from "lucide-react";
+import { Building2, UserCog } from "lucide-react";
 
 import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { PageHeader } from "@/components/primitives/page-header";
 import { SelfAccountSettings } from "@/components/sysadmin/self-account-form";
+import { SystemConfigForm } from "@/components/sysadmin/system-config-form";
 import { explainError } from "@/lib/error-codes";
 import { fmtDateTime } from "@/lib/format";
 import { useSystemConfig } from "@/lib/use-api";
@@ -19,7 +20,7 @@ export default function SysAdminHome() {
         label="Sys-admin"
         title="Your account"
         highlight="& system."
-        subtitle="Manage your own ops account, and review the system configuration the operator picked during first-run setup."
+        subtitle="Manage your own ops account and the clinic configuration."
       />
 
       <section className="flex flex-col gap-4">
@@ -36,83 +37,24 @@ export default function SysAdminHome() {
           <h2 className="font-display text-lg tracking-[-0.01em]">System configuration</h2>
         </div>
 
-      {error ? (
-        <ErrorBanner>{explainError(error.error)}</ErrorBanner>
-      ) : isLoading || !data ? (
-        <Card className="p-8 text-center text-sm text-[var(--muted-foreground)]">Loading…</Card>
-      ) : (
-        <div className="grid gap-4 lg:grid-cols-2">
+        {error ? (
+          <ErrorBanner>{explainError(error.error)}</ErrorBanner>
+        ) : isLoading || !data ? (
+          <Card className="p-8 text-center text-sm text-[var(--muted-foreground)]">Loading…</Card>
+        ) : (
           <Card className="p-6">
-            <header className="flex items-center gap-2 border-b border-[var(--border)] pb-3">
-              <Building2 className="h-4 w-4 text-[var(--accent)]" />
-              <h2 className="font-display text-lg tracking-[-0.01em]">Institute identity</h2>
-            </header>
-            <dl className="mt-4 flex flex-col gap-3">
-              <Row Icon={ShieldCheck} label="Name" value={data.instituteName} />
-              <Row
-                Icon={MapPin}
-                label="Address"
-                value={
-                  data.instituteAddressLines && data.instituteAddressLines.length > 0
-                    ? data.instituteAddressLines.join(" · ")
-                    : null
-                }
-              />
-              <Row Icon={Phone} label="Phone" value={data.instituteContactPhone} />
-              <Row Icon={Mail} label="Email" value={data.instituteContactEmail} />
+            <dl className="mb-4 flex flex-col gap-1 border-b border-[var(--border)] pb-4">
+              <dt className="font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+                Initialized at
+              </dt>
+              <dd className="text-sm text-[var(--foreground)]">
+                {data.initializedAt ? fmtDateTime(data.initializedAt) : "—"}
+              </dd>
             </dl>
+            <SystemConfigForm config={data} />
           </Card>
-
-          <Card className="p-6">
-            <header className="flex items-center gap-2 border-b border-[var(--border)] pb-3">
-              <Clock className="h-4 w-4 text-[var(--accent)]" />
-              <h2 className="font-display text-lg tracking-[-0.01em]">Defaults</h2>
-            </header>
-            <dl className="mt-4 flex flex-col gap-3">
-              <Row Icon={Clock} label="App timezone" value={data.appTimezone} />
-              <Row Icon={Clock} label="Export timezone" value={data.exportTimezone} />
-              <Row Icon={FileText} label="Master consent version" value={data.masterConsentVersion} />
-              <Row
-                Icon={ShieldCheck}
-                label="Initialized at"
-                value={data.initializedAt ? fmtDateTime(data.initializedAt) : null}
-              />
-            </dl>
-          </Card>
-        </div>
-      )}
-
-        <p className="text-xs text-[var(--muted-foreground)]">
-          Read-only for now. Editing these values is planned for a future dev-dashboard release; until
-          then, an operator can re-initialize the system by following the manual procedure in{" "}
-          <code className="rounded bg-[var(--muted)] px-1 py-0.5 font-mono text-[11px]">
-            CURRENT_INFRA.md
-          </code>{" "}
-          §6.
-        </p>
+        )}
       </section>
-    </div>
-  );
-}
-
-function Row({
-  Icon,
-  label,
-  value,
-}: {
-  Icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: string | null | undefined;
-}) {
-  return (
-    <div className="flex items-start gap-3">
-      <Icon className="mt-0.5 h-4 w-4 shrink-0 text-[var(--muted-foreground)]" />
-      <div className="min-w-0 flex-1">
-        <dt className="font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
-          {label}
-        </dt>
-        <dd className="mt-0.5 truncate text-sm text-[var(--foreground)]">{value ?? "—"}</dd>
-      </div>
     </div>
   );
 }

--- a/frontend/src/components/sysadmin/system-config-form.tsx
+++ b/frontend/src/components/sysadmin/system-config-form.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { CheckCircle2 } from "lucide-react";
+
+import { Button } from "@/components/primitives/button";
+import { ErrorBanner } from "@/components/primitives/error-banner";
+import { Input, Label } from "@/components/primitives/input";
+import { Select, Textarea } from "@/components/primitives/select";
+import { explainError } from "@/lib/error-codes";
+import { useUpdateSystemConfig } from "@/lib/use-api";
+import type { SystemConfig } from "@/types/api";
+import { Field, Hint, Section } from "./account-sections";
+
+// Address lines stored as string[] but edited as a textarea (one line = one entry).
+function addrToText(lines: string[] | null | undefined): string {
+  return lines?.join("\n") ?? "";
+}
+function textToAddr(text: string): string[] | null {
+  const lines = text
+    .split("\n")
+    .map((l) => l.trim())
+    .filter(Boolean);
+  return lines.length > 0 ? lines : null;
+}
+
+// All IANA timezone names available in the browser, grouped by region prefix.
+function useTimezoneOptions() {
+  return useMemo(() => {
+    const all: string[] = Intl.supportedValuesOf("timeZone");
+    const groups: Record<string, string[]> = {};
+    for (const tz of all) {
+      const region = tz.includes("/") ? tz.split("/")[0] : "Other";
+      (groups[region] ??= []).push(tz);
+    }
+    return Object.entries(groups).sort(([a], [b]) => a.localeCompare(b));
+  }, []);
+}
+
+function TimezoneSelect({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const groups = useTimezoneOptions();
+  return (
+    <Select value={value} onChange={(e) => onChange(e.target.value)}>
+      <option value="">— select timezone —</option>
+      {groups.map(([region, zones]) => (
+        <optgroup key={region} label={region}>
+          {zones.map((tz) => (
+            <option key={tz} value={tz}>
+              {tz}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </Select>
+  );
+}
+
+export function SystemConfigForm({ config }: { config: SystemConfig }) {
+  const update = useUpdateSystemConfig();
+  const [done, setDone] = useState(false);
+
+  const [instituteName, setInstituteName] = useState(config.instituteName ?? "");
+  const [addressText, setAddressText] = useState(addrToText(config.instituteAddressLines));
+  const [phone, setPhone] = useState(config.instituteContactPhone ?? "");
+  const [email, setEmail] = useState(config.instituteContactEmail ?? "");
+  const [appTz, setAppTz] = useState(config.appTimezone ?? "");
+  const [exportTz, setExportTz] = useState(config.exportTimezone ?? "");
+  const [consentVersion, setConsentVersion] = useState(config.masterConsentVersion ?? "");
+
+  const dirty =
+    instituteName !== (config.instituteName ?? "") ||
+    addressText !== addrToText(config.instituteAddressLines) ||
+    phone !== (config.instituteContactPhone ?? "") ||
+    email !== (config.instituteContactEmail ?? "") ||
+    appTz !== (config.appTimezone ?? "") ||
+    exportTz !== (config.exportTimezone ?? "") ||
+    consentVersion !== (config.masterConsentVersion ?? "");
+
+  function handleSave() {
+    setDone(false);
+    update.mutate(
+      {
+        instituteName: instituteName || null,
+        instituteAddressLines: textToAddr(addressText),
+        instituteContactPhone: phone || null,
+        instituteContactEmail: email || null,
+        appTimezone: appTz || null,
+        exportTimezone: exportTz || null,
+        masterConsentVersion: consentVersion || null,
+      },
+      { onSuccess: () => setDone(true) },
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Section title="Institute identity">
+        <Field label="Institute name">
+          <Input
+            value={instituteName}
+            onChange={(e) => setInstituteName(e.target.value)}
+            placeholder="e.g. Hapu Eye Clinic"
+          />
+        </Field>
+        <Field label="Address lines">
+          <Textarea
+            value={addressText}
+            onChange={(e) => setAddressText(e.target.value)}
+            rows={3}
+            placeholder={"Line 1\nLine 2\nLine 3"}
+          />
+          <Hint>One line per address entry.</Hint>
+        </Field>
+        <Field label="Contact phone">
+          <Input
+            value={phone}
+            onChange={(e) => setPhone(e.target.value)}
+            placeholder="e.g. +94 11 234 5678"
+          />
+        </Field>
+        <Field label="Contact email">
+          <Input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="e.g. contact@clinic.lk"
+          />
+        </Field>
+      </Section>
+
+      <Section title="Defaults">
+        <Field label="App timezone">
+          <TimezoneSelect value={appTz} onChange={setAppTz} />
+          <Hint>Used for scheduling and display.</Hint>
+        </Field>
+        <Field label="Export timezone">
+          <TimezoneSelect value={exportTz} onChange={setExportTz} />
+          <Hint>Used when exporting reports.</Hint>
+        </Field>
+        <Field label="Master consent version">
+          <Input
+            value={consentVersion}
+            onChange={(e) => setConsentVersion(e.target.value)}
+            placeholder="e.g. 1.0"
+          />
+          <Hint>Version token printed on consent forms.</Hint>
+        </Field>
+      </Section>
+
+      {update.error ? <ErrorBanner>{explainError(update.error.error)}</ErrorBanner> : null}
+
+      <div className="flex items-center gap-3">
+        <Button onClick={handleSave} disabled={!dirty || update.isPending}>
+          {update.isPending ? "Saving…" : "Save changes"}
+        </Button>
+        {done && !dirty ? (
+          <span className="inline-flex items-center gap-1.5 font-mono text-[10px] uppercase tracking-[0.12em] text-emerald-700">
+            <CheckCircle2 className="h-3.5 w-3.5" />
+            Saved
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -85,6 +85,9 @@ const MESSAGES: Record<string, string> = {
     "This action only applies to rejected doctors.",
   invalid_status:
     "Unknown doctor status filter.",
+  // Sys-admin system config.
+  system_config_not_found: "System configuration is missing — the system may not have been initialized.",
+  invalid_timezone: "That timezone isn't recognized. Use an IANA timezone name like Asia/Colombo or UTC.",
   // Sys-admin account management.
   account_disabled:
     "This account has been disabled. Contact your system administrator to re-enable it.",

--- a/frontend/src/lib/use-api.ts
+++ b/frontend/src/lib/use-api.ts
@@ -65,6 +65,7 @@ import type {
   SubmitConsultationResponse as TSubmitConsultationResponse,
   SysadminMe,
   SystemConfig,
+  SystemConfigUpdateRequest,
   VerifySetupTokenRequest,
   VerifySetupTokenResponse,
 } from "@/types/api";
@@ -1005,6 +1006,18 @@ export function useSystemConfig() {
   return useQuery({
     queryKey: ["sysadmin", "system-config"],
     queryFn: () => fetcher<SystemConfig>("/sysadmin/system-config"),
+  });
+}
+
+export function useUpdateSystemConfig() {
+  const fetcher = useAuthedApi();
+  const qc = useQueryClient();
+  return useMutation<SystemConfig, ApiError, SystemConfigUpdateRequest>({
+    mutationFn: (body) =>
+      fetcher<SystemConfig>("/sysadmin/system-config", { method: "PATCH", body }),
+    onSuccess: (data) => {
+      qc.setQueryData(["sysadmin", "system-config"], data);
+    },
   });
 }
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -426,7 +426,7 @@ export type SysadminMe = {
   contact: string | null;
 };
 
-// ── Sys-admin read-only views ─────────────────────────────────────────
+// ── Sys-admin system config ───────────────────────────────────────────
 
 export type SystemConfig = {
   initializedAt: string | null;
@@ -437,6 +437,17 @@ export type SystemConfig = {
   appTimezone: string | null;
   exportTimezone: string | null;
   masterConsentVersion: string | null;
+};
+
+// PATCH /sysadmin/system-config — all fields optional (PATCH semantics).
+export type SystemConfigUpdateRequest = {
+  instituteName?: string | null;
+  instituteAddressLines?: string[] | null;
+  instituteContactPhone?: string | null;
+  instituteContactEmail?: string | null;
+  appTimezone?: string | null;
+  exportTimezone?: string | null;
+  masterConsentVersion?: string | null;
 };
 
 // ── Wrappers used by certain endpoints ───────────────────────────────


### PR DESCRIPTION
## Summary

- **Backend**: adds `PATCH /sysadmin/system-config` — updates all `SystemConfig` fields (institute name, address lines, contact phone/email, app/export timezones, consent version) and reloads the in-memory `LiveConfig` cache immediately so runtime consumers (PDF, exports) see the change without a restart. Timezones are validated against the IANA database before saving.
- **Frontend**: replaces the read-only system config display with an editable form (`SystemConfigForm`); timezone fields use a `<Select>` populated from `Intl.supportedValuesOf('timeZone')` grouped by region — only valid IANA names are selectable. Address lines use a `<Textarea>` (one line per entry). Dirty-flag-driven save button; success badge on completion.
- Own-account editing (profile + password) was already implemented; this completes the full settings surface for the sys-admin.

## Test Plan

- [ ] Log in as `superuser` → navigate to `/sysadmin`
- [ ] Edit institute name, address lines, phone, email → Save → values persist after page reload
- [ ] Change App/Export timezone via dropdown → Save → verify only IANA names appear in the select
- [ ] Change master consent version → Save → new patients get the updated version on consent forms
- [ ] Verify "Save changes" button is disabled until a field is dirtied
- [ ] Verify "Saved" badge appears after a successful save and disappears once you change a field again
- [ ] Attempt to submit an invalid timezone via API directly (`curl -X PATCH ...`) → confirm `422 invalid_timezone`

🤖 Generated with [Claude Code](https://claude.com/claude-code)