### PR TITLE
fix(frontend): strip whitespace from auth + identity fields

### DIFF
--- a/frontend/src/app/(app)/sysadmin/accounts/page.tsx
+++ b/frontend/src/app/(app)/sysadmin/accounts/page.tsx
@@ -410,13 +410,16 @@ function CreateAccountModal({ open, onClose }: { open: boolean; onClose: () => v
     e.preventDefault();
     setLocalError(null);
     if (!username.trim()) return setLocalError("Username is required.");
-    if (password.length < MIN_PASSWORD_LEN)
+    // Trim before validating/sending so the stored secret matches what
+    // /auth/login trims on the way back in.
+    const pw = password.trim();
+    if (pw.length < MIN_PASSWORD_LEN)
       return setLocalError(`Password must be at least ${MIN_PASSWORD_LEN} characters.`);
-    if (password !== confirm) return setLocalError("Passwords do not match.");
+    if (pw !== confirm.trim()) return setLocalError("Passwords do not match.");
     create.mutate(
       {
         username: username.trim(),
-        password,
+        password: pw,
         role,
         fullName: fullName.trim() || undefined,
         contact: contact.trim() || undefined,

--- a/frontend/src/app/doctor-onboarding/[token]/page.tsx
+++ b/frontend/src/app/doctor-onboarding/[token]/page.tsx
@@ -238,11 +238,14 @@ function RotationPanel({
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (password.length < MIN_PASSWORD_LEN) {
+    // Trim before validating/sending so the stored secret matches what
+    // /auth/login trims on the way back in.
+    const pw = password.trim();
+    if (pw.length < MIN_PASSWORD_LEN) {
       setError(`Choose a password at least ${MIN_PASSWORD_LEN} characters long.`);
       return;
     }
-    if (password !== confirm) {
+    if (pw !== confirm.trim()) {
       setError("Passwords don't match. Re-enter to confirm.");
       return;
     }
@@ -250,7 +253,7 @@ function RotationPanel({
     try {
       await api(`/doctor-onboarding/${token}`, {
         method: "POST",
-        body: { password },
+        body: { password: pw },
         skipAuthRedirect: true,
       });
       onDone();

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -67,7 +67,10 @@ function LoginScreen() {
     try {
       const res = await api<LoginResponse>("/auth/login", {
         method: "POST",
-        body: { username, password },
+        // Trim both fields — a stray leading/trailing space pasted into
+        // either turns a valid login into invalid_credentials. Passwords
+        // are stored trimmed everywhere they're set, so this stays in sync.
+        body: { username: username.trim(), password: password.trim() },
       });
       login({ username: res.username, role: res.role, expiresAt: res.expiresAt });
       const next = search.get("next") || ROLE_HOMES[res.role];

--- a/frontend/src/app/setup/page.tsx
+++ b/frontend/src/app/setup/page.tsx
@@ -283,11 +283,14 @@ function ConfigureStage({
 
     if (!username.trim()) next.username = "Username is required.";
 
-    if (!password) next.password = "Password is required.";
-    else if (password.length < 10) next.password = "Password must be at least 10 characters.";
+    // Validate the trimmed password so whitespace can't pad a short secret
+    // past the length gate, and so it matches what /auth/login submits.
+    const pw = password.trim();
+    if (!pw) next.password = "Password is required.";
+    else if (pw.length < 10) next.password = "Password must be at least 10 characters.";
 
     if (!passwordConfirm) next.passwordConfirm = "Confirm your password.";
-    else if (password && password !== passwordConfirm) next.passwordConfirm = "Passwords don't match.";
+    else if (pw && pw !== passwordConfirm.trim()) next.passwordConfirm = "Passwords don't match.";
 
     if (!instituteName.trim()) next.instituteName = "Institute name is required.";
 
@@ -303,7 +306,7 @@ function ConfigureStage({
     try {
       const result = await initialize.mutateAsync({
         body: {
-          sysAdmin: { username: username.trim(), password },
+          sysAdmin: { username: username.trim(), password: pw },
           instituteIdentity: {
             name: instituteName.trim(),
             addressLines: lines,

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -184,9 +184,10 @@ export function DoctorForm({
       if (signature) payload.defaultSignatureImage = signature;
       if (isSelfOnboarding) {
         // Self-onboarding: password is always sent (validated above).
-        payload.password = v.password;
+        // Trimmed so it matches what /auth/login trims on the way back in.
+        payload.password = v.password?.trim();
       } else if (onboardingMode === "manual" && v.password) {
-        payload.password = v.password;
+        payload.password = v.password.trim();
       }
       // admin invite mode → payload.password stays undefined; backend fires invite
     } else {
@@ -196,7 +197,8 @@ export function DoctorForm({
       } else if (signature) {
         payload.defaultSignatureImage = signature;
       }
-      if (v.password && v.password.trim()) payload.password = v.password;
+      // Trimmed so it matches what /auth/login trims on the way back in.
+      if (v.password && v.password.trim()) payload.password = v.password.trim();
     }
     onSubmit(payload);
   });

--- a/frontend/src/components/sysadmin/account-sections.tsx
+++ b/frontend/src/components/sysadmin/account-sections.tsx
@@ -44,7 +44,7 @@ export function ProfileSection({
       {update.error ? <ErrorBanner>{explainError(update.error.error)}</ErrorBanner> : null}
       <div>
         <Button
-          onClick={() => update.mutate({ username: account.username, body: { fullName, contact } }, { onSuccess: onSaved })}
+          onClick={() => update.mutate({ username: account.username, body: { fullName: fullName.trim(), contact: contact.trim() } }, { onSuccess: onSaved })}
           disabled={!dirty || update.isPending}
         >
           {update.isPending ? "Saving…" : "Save changes"}
@@ -66,11 +66,14 @@ export function PasswordSection({ username, self = false }: { username: string; 
     e.preventDefault();
     setPwError(null);
     setPwDone(false);
-    if (password.length < MIN_PASSWORD_LEN)
+    // Trim before validating/sending so the stored secret matches what
+    // /auth/login trims on the way back in.
+    const pw = password.trim();
+    if (pw.length < MIN_PASSWORD_LEN)
       return setPwError(`Password must be at least ${MIN_PASSWORD_LEN} characters.`);
-    if (password !== confirm) return setPwError("Passwords do not match.");
+    if (pw !== confirm.trim()) return setPwError("Passwords do not match.");
     resetPw.mutate(
-      { username, password },
+      { username, password: pw },
       {
         onSuccess: () => {
           setPassword("");

--- a/frontend/src/components/sysadmin/system-config-form.tsx
+++ b/frontend/src/components/sysadmin/system-config-form.tsx
@@ -84,15 +84,19 @@ export function SystemConfigForm({ config }: { config: SystemConfig }) {
 
   function handleSave() {
     setDone(false);
+    // Trim free-text fields so a stray space can't drift the saved identity
+    // away from what the setup wizard stores (it trims the same fields).
+    // Address lines are already trimmed by textToAddr; timezones come from a
+    // <Select> so they need no trimming.
     update.mutate(
       {
-        instituteName: instituteName || null,
+        instituteName: instituteName.trim() || null,
         instituteAddressLines: textToAddr(addressText),
-        instituteContactPhone: phone || null,
-        instituteContactEmail: email || null,
+        instituteContactPhone: phone.trim() || null,
+        instituteContactEmail: email.trim() || null,
         appTimezone: appTz || null,
         exportTimezone: exportTz || null,
-        masterConsentVersion: consentVersion || null,
+        masterConsentVersion: consentVersion.trim() || null,
       },
       { onSuccess: () => setDone(true) },
     );


### PR DESCRIPTION
## Problem

The login form submitted `username` and `password` **verbatim**, so a stray leading/trailing space (easy to introduce when pasting) turned a valid credential into `invalid_credentials`. More broadly, whitespace handling across the auth/identity forms was inconsistent — some trimmed on submit, some didn't.

## Approach

The convention in this codebase is **trim on submit**. The backend never trims passwords and matches the username as an exact primary-key lookup (`db.get(Account, payload.username)`), so the **frontend owns** this consistency. The fix trims at *every* point a credential or identity value is entered — both where it's **set** and where it's **verified** — so set-time and login-time always agree.

## Changes

- **Login** — trim `username` + `password` before `POST /auth/login`
- **Setup wizard** — validate/submit the *trimmed* sys-admin password (so whitespace can't pad a short secret past the 10-char gate)
- **Sysadmin create-account & password reset** — trim before validate/send
- **Doctor onboarding (rotation)** + **`doctor-form`** (create / manual / self-onboarding / edit) — trim the password feeding the payload
- **Sysadmin profile section** — trim `fullName` / `contact` on save (was the only profile form with no trimming)
- **System config form** — trim institute name / phone / email / consent version, matching what the setup wizard already stores for the same fields

Trimming is **leading/trailing only** — internal spaces in a passphrase are preserved.

## Validation

- `tsc --noEmit` passes (0 errors)
- Branched off latest `origin/main` (`2ad0ac1`); resolved one merge with upstream's `doctor-form.tsx` rewrite (kept their new signature-clearing logic, applied the trim to the password line)

## Note

Any password **already stored** (hashed) before this change with surrounding whitespace would no longer match, since login now trims. Such passwords are rare/accidental; flagging for awareness.

Closes #45 

🤖 Generated with [Claude Code](https://claude.com/claude-code)