### PR TITLE
feat(ux): confirm-password coverage, drag-and-drop uploads, click-safe modals

### DIFF
--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -37,6 +37,7 @@ const createSchema = z.object({
   ...baseFields,
   username: z.string().min(1, "Username is required"),
   password: z.string().optional(),
+  passwordConfirm: z.string().optional(),
 });
 
 type OnboardingMode = "invite" | "manual";
@@ -44,6 +45,7 @@ type OnboardingMode = "invite" | "manual";
 const updateSchema = z.object({
   ...baseFields,
   password: z.string().optional(),
+  passwordConfirm: z.string().optional(),
 });
 
 export type DoctorFormPayload = {
@@ -132,6 +134,7 @@ export function DoctorForm({
       instituteContact: initial?.instituteContact ?? "",
       username: "",
       password: "",
+      passwordConfirm: "",
     } as Values,
   });
 
@@ -158,6 +161,12 @@ export function DoctorForm({
     }
     if (isCreate && isSelfOnboarding && (!v.password || !v.password.trim())) {
       setPasswordError("Pick a password.");
+      return;
+    }
+    // Whenever a password is being set (create, manual, self-onboarding, or an
+    // edit-mode rotation), the confirmation must match it.
+    if (v.password && v.password.trim() && v.password !== v.passwordConfirm) {
+      setPasswordError("Passwords do not match.");
       return;
     }
     setPasswordError(null);
@@ -275,13 +284,26 @@ export function DoctorForm({
               in admin "invite" create mode since the doctor will set it
               via the onboarding link. */}
           {(!isCreate || isSelfOnboarding || onboardingMode === "manual") && (
-            <Field
-              label={isCreate ? "Password *" : "New password (leave blank to keep)"}
-              htmlFor="password"
-              error={passwordError ?? errors.password?.message}
-            >
-              <Input id="password" type="password" {...register("password")} autoComplete="new-password" />
-            </Field>
+            <>
+              <Field
+                label={isCreate ? "Password *" : "New password (leave blank to keep)"}
+                htmlFor="password"
+                error={passwordError ?? errors.password?.message}
+              >
+                <Input id="password" type="password" {...register("password")} autoComplete="new-password" />
+              </Field>
+              <Field
+                label={isCreate ? "Confirm password *" : "Confirm new password"}
+                htmlFor="passwordConfirm"
+              >
+                <Input
+                  id="passwordConfirm"
+                  type="password"
+                  {...register("passwordConfirm")}
+                  autoComplete="new-password"
+                />
+              </Field>
+            </>
           )}
         </div>
         {isCreate && !isSelfOnboarding && onboardingMode === "invite" && (

--- a/frontend/src/components/admin/doctor-form.tsx
+++ b/frontend/src/components/admin/doctor-form.tsx
@@ -169,8 +169,9 @@ export function DoctorForm({
       return;
     }
     // Whenever a password is being set (create, manual, self-onboarding, or an
-    // edit-mode rotation), the confirmation must match it.
-    if (v.password && v.password.trim() && v.password !== v.passwordConfirm) {
+    // edit-mode rotation), the confirmation must match it. Compared trimmed to
+    // match what the submit handler sends and what /auth/login trims back in.
+    if (v.password && v.password.trim() && v.password.trim() !== (v.passwordConfirm ?? "").trim()) {
       setPasswordError("Passwords do not match.");
       return;
     }

--- a/frontend/src/components/admin/rubber-stamp-uploader.tsx
+++ b/frontend/src/components/admin/rubber-stamp-uploader.tsx
@@ -9,6 +9,7 @@ import { ErrorBanner } from "@/components/primitives/error-banner";
 import { Modal } from "@/components/primitives/modal";
 import { QrCaptureModal } from "@/components/primitives/qr-capture-modal";
 import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
+import { useFileDrop } from "@/lib/use-file-drop";
 
 const MAX_BYTES = 1_000_000; // 1 MB — keeps the patient PDF lean
 const ACCEPTED = ["image/png", "image/jpeg"];
@@ -64,10 +65,20 @@ export function RubberStampUploader({
     if (file) processFile(file);
   };
 
+  // Drag a PNG/JPEG anywhere onto the uploader (empty dropzone or the captured
+  // card) to load it into the editor — same path as the file picker.
+  const { isDragging, dropProps } = useFileDrop((files) => processFile(files[0]));
+
   return (
     <div className="flex flex-col gap-3">
       {value ? (
-        <div className="flex items-center gap-4 rounded-xl border border-[var(--border)] bg-[var(--card)] p-4">
+        <div
+          {...dropProps}
+          className={
+            "flex items-center gap-4 rounded-xl border bg-[var(--card)] p-4 transition-colors " +
+            (isDragging ? "border-[var(--accent)] bg-[var(--accent)]/[0.04]" : "border-[var(--border)]")
+          }
+        >
           <button
             type="button"
             onClick={() => setPreviewOpen(true)}
@@ -141,15 +152,23 @@ export function RubberStampUploader({
           <button
             type="button"
             onClick={() => inputRef.current?.click()}
-            className="group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/30 px-6 py-10 transition-colors hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]"
+            {...dropProps}
+            className={
+              "group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-10 transition-colors " +
+              (isDragging
+                ? "border-[var(--accent)] bg-[var(--accent)]/[0.06]"
+                : "border-[var(--border)] bg-[var(--muted)]/30 hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]")
+            }
           >
             <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-3 text-white shadow-accent transition-transform duration-300 group-hover:scale-110">
               <Stamp className="h-5 w-5" />
             </div>
             <div className="text-center">
-              <div className="text-sm font-semibold tracking-[-0.01em]">Upload rubber stamp</div>
+              <div className="text-sm font-semibold tracking-[-0.01em]">
+                {isDragging ? "Drop image to upload" : "Upload rubber stamp"}
+              </div>
               <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
-                PNG or JPEG · &lt; 1 MB · crop &amp; remove background after upload
+                Drag &amp; drop or click · PNG or JPEG · &lt; 1 MB · crop &amp; remove background after upload
               </div>
             </div>
           </button>

--- a/frontend/src/components/doctor/signature-input.tsx
+++ b/frontend/src/components/doctor/signature-input.tsx
@@ -8,6 +8,7 @@ import { ErrorBanner } from "@/components/primitives/error-banner";
 import { Modal } from "@/components/primitives/modal";
 import { RubberStampEditor } from "@/components/admin/rubber-stamp-editor";
 import { SignatureCanvas, type SignatureCanvasHandle } from "@/components/doctor/signature-canvas";
+import { useFileDrop } from "@/lib/use-file-drop";
 
 // Uploads accept PNG/JPEG (a photo of a signature is fine) — the editor crops
 // and removes the paper background, then re-encodes to PNG. Pre-edit budget is
@@ -43,10 +44,9 @@ export function SignatureInput({
   // The uploaded image being cropped / background-removed in the editor modal.
   const [editorSource, setEditorSource] = useState<string | null>(null);
 
-  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    e.target.value = ""; // allow re-picking the same file
-    if (!file) return;
+  // Validate then read a file → data URL → open the editor. Shared by the file
+  // picker and drag-and-drop.
+  const processFile = (file: File) => {
     setError(null);
     if (!ACCEPTED.includes(file.type)) {
       setError("Use a PNG or JPEG image.");
@@ -64,6 +64,14 @@ export function SignatureInput({
     reader.onerror = () => setError("Couldn't read the file. Try again.");
     reader.readAsDataURL(file);
   };
+
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    e.target.value = ""; // allow re-picking the same file
+    if (file) processFile(file);
+  };
+
+  const { isDragging, dropProps } = useFileDrop((files) => processFile(files[0]));
 
   // Editor "Apply" — accept the cropped PNG only if it fits the server cap,
   // otherwise keep the editor open and nudge the doctor to crop tighter.
@@ -133,15 +141,23 @@ export function SignatureInput({
         <button
           type="button"
           onClick={() => inputRef.current?.click()}
-          className="group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed border-[var(--border)] bg-[var(--muted)]/30 px-6 py-10 transition-colors hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]"
+          {...dropProps}
+          className={
+            "group flex flex-col items-center justify-center gap-3 rounded-xl border-2 border-dashed px-6 py-10 transition-colors " +
+            (isDragging
+              ? "border-[var(--accent)] bg-[var(--accent)]/[0.06]"
+              : "border-[var(--border)] bg-[var(--muted)]/30 hover:border-[var(--accent)]/40 hover:bg-[var(--accent)]/[0.03]")
+          }
         >
           <div className="rounded-xl bg-gradient-to-br from-[var(--accent)] to-[var(--accent-secondary)] p-3 text-white shadow-accent transition-transform duration-300 group-hover:scale-110">
             <Upload className="h-5 w-5" />
           </div>
           <div className="text-center">
-            <div className="text-sm font-semibold tracking-[-0.01em]">Upload signature</div>
+            <div className="text-sm font-semibold tracking-[-0.01em]">
+              {isDragging ? "Drop image to upload" : "Upload signature"}
+            </div>
             <div className="mt-0.5 font-mono text-[10px] uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
-              PNG or JPEG · crop &amp; remove background after upload
+              Drag &amp; drop or click · PNG or JPEG · crop &amp; remove background after upload
             </div>
           </div>
         </button>

--- a/frontend/src/components/healthworker/attachments-panel.tsx
+++ b/frontend/src/components/healthworker/attachments-panel.tsx
@@ -17,6 +17,7 @@ import {
   useDeleteAttachment,
   useUploadAttachment,
 } from "@/lib/use-api";
+import { useFileDrop } from "@/lib/use-file-drop";
 import type { AppointmentStatus, AttachmentMeta } from "@/types/api";
 
 const READONLY_STATES: AppointmentStatus[] = ["completed", "cancelled"];
@@ -60,8 +61,22 @@ export function AttachmentsPanel({
     if (fileInput.current) fileInput.current.value = "";
   };
 
+  // Drag photos straight onto the card to upload them — disabled once the
+  // appointment is locked or while an upload is already in flight.
+  const { isDragging, dropProps } = useFileDrop((files) => uploadFiles(files), {
+    multiple: true,
+    disabled: readonly || upload.isPending,
+  });
+
   return (
-    <Card variant="elevated" className="p-6">
+    <Card
+      variant="elevated"
+      {...dropProps}
+      className={
+        "p-6 transition-colors " +
+        (isDragging ? "ring-2 ring-[var(--accent)] ring-offset-2 ring-offset-[var(--background)]" : "")
+      }
+    >
       <div className="mb-4 flex items-start gap-3">
         <div className="rounded-xl bg-[var(--accent)]/10 p-2">
           <Camera className="h-5 w-5 text-[var(--accent)]" />
@@ -130,7 +145,7 @@ export function AttachmentsPanel({
         </div>
       ) : (
         <p className="rounded-xl border border-dashed border-[var(--border)] p-6 text-center text-sm text-[var(--muted-foreground)]">
-          No photos yet.
+          {readonly ? "No photos." : "No photos yet — drag photos here or use the buttons above."}
         </p>
       )}
 

--- a/frontend/src/components/primitives/camera-capture-modal.tsx
+++ b/frontend/src/components/primitives/camera-capture-modal.tsx
@@ -44,17 +44,15 @@ export function CameraCaptureModal({
     setShot(url);
   };
 
-  // Esc to close + lock body scroll while open.
+  // Lock body scroll while open. Closes only via the X button — no Esc or
+  // backdrop click, so a stray click can't drop you out mid-capture.
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
-      document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open]);
 
   // Start/stop the stream as the modal opens or the camera is flipped. We keep
   // the stream live after a shot so "Retake" is instant.
@@ -175,7 +173,6 @@ export function CameraCaptureModal({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.18 }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
-          onClick={onClose}
           role="dialog"
           aria-modal
         >
@@ -184,7 +181,6 @@ export function CameraCaptureModal({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 8, scale: 0.97 }}
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
-            onClick={(e) => e.stopPropagation()}
             className="flex max-h-full w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
           >
             <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">

--- a/frontend/src/components/primitives/image-preview-modal.tsx
+++ b/frontend/src/components/primitives/image-preview-modal.tsx
@@ -7,9 +7,9 @@ import { useEffect } from "react";
 import { Button } from "@/components/primitives/button";
 
 // Image lightbox styled as a popup window — a framed panel with a header bar
-// (title + an explicit X close button) and the image in the body. Esc or
-// backdrop click also close. Used so attachments open in-app instead of a raw
-// new-tab file view.
+// (title + an explicit X close button) and the image in the body. Closes only
+// via the X button (no Esc or backdrop click), matching every other modal.
+// Used so attachments open in-app instead of a raw new-tab file view.
 export function ImagePreviewModal({
   open,
   onClose,
@@ -23,16 +23,15 @@ export function ImagePreviewModal({
   alt: string;
   title?: string | null;
 }) {
+  // Lock body scroll while open. Closes only via the X button — no Esc or
+  // backdrop click — matching every other modal.
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
-      document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open]);
 
   return (
     <AnimatePresence>
@@ -43,7 +42,6 @@ export function ImagePreviewModal({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.18 }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
-          onClick={onClose}
           role="dialog"
           aria-modal
         >
@@ -52,7 +50,6 @@ export function ImagePreviewModal({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 8, scale: 0.97 }}
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
-            onClick={(e) => e.stopPropagation()}
             className="flex max-h-full w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
           >
             <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">

--- a/frontend/src/components/primitives/modal.tsx
+++ b/frontend/src/components/primitives/modal.tsx
@@ -8,7 +8,9 @@ import { Button } from "@/components/primitives/button";
 import { cn } from "@/lib/cn";
 
 // Lightweight modal — backdrop fade + content scale-in. No focus trap library;
-// for forms-with-submit-button this is fine. Esc to close.
+// for forms-with-submit-button this is fine. Closes ONLY via the X button (or an
+// explicit in-content action) — a backdrop click or Esc no longer dismisses it,
+// so half-typed forms aren't lost to a stray click outside the box.
 export function Modal({
   open,
   onClose,
@@ -24,16 +26,14 @@ export function Modal({
   children: ReactNode;
   className?: string;
 }) {
+  // Lock body scroll while open. Esc intentionally does not close — see header.
   useEffect(() => {
     if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
-      document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
     };
-  }, [open, onClose]);
+  }, [open]);
 
   return (
     <AnimatePresence>
@@ -44,7 +44,6 @@ export function Modal({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.18 }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/30 px-4 backdrop-blur-sm"
-          onClick={onClose}
           role="dialog"
           aria-modal
         >
@@ -53,7 +52,6 @@ export function Modal({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 8, scale: 0.97 }}
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
-            onClick={(e) => e.stopPropagation()}
             className={cn(
               "relative w-full max-w-md rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl",
               className,

--- a/frontend/src/components/primitives/qr-capture-modal.tsx
+++ b/frontend/src/components/primitives/qr-capture-modal.tsx
@@ -182,7 +182,6 @@ export function QrCaptureModal({
           exit={{ opacity: 0 }}
           transition={{ duration: 0.18 }}
           className="fixed inset-0 z-50 flex items-center justify-center bg-[var(--foreground)]/50 p-4 backdrop-blur-sm sm:p-8"
-          onClick={onClose}
           role="dialog"
           aria-modal
         >
@@ -191,7 +190,6 @@ export function QrCaptureModal({
             animate={{ opacity: 1, y: 0, scale: 1 }}
             exit={{ opacity: 0, y: 8, scale: 0.97 }}
             transition={{ duration: 0.22, ease: [0.16, 1, 0.3, 1] }}
-            onClick={(e) => e.stopPropagation()}
             className="flex max-h-full w-full max-w-md flex-col overflow-hidden rounded-2xl border border-[var(--border)] bg-[var(--card)] shadow-xl"
           >
             <div className="flex items-center justify-between gap-3 border-b border-[var(--border)] px-4 py-3">

--- a/frontend/src/lib/use-file-drop.ts
+++ b/frontend/src/lib/use-file-drop.ts
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useRef, useState, type DragEvent } from "react";
+
+// Drag-and-drop file handling for upload zones. Spread `dropProps` on the drop
+// target and use `isDragging` to highlight it; dropped files are handed to
+// `onFiles`. Single-file targets get just the first file (multiple: false,
+// the default); multi-file targets get them all. Pointer/keyboard upload paths
+// are untouched — this only adds drag-and-drop on top.
+export function useFileDrop(
+  onFiles: (files: File[]) => void,
+  opts?: { multiple?: boolean; disabled?: boolean },
+) {
+  const multiple = opts?.multiple ?? false;
+  const disabled = opts?.disabled ?? false;
+  const [isDragging, setIsDragging] = useState(false);
+  // dragenter/dragleave fire for every child element the cursor crosses; a
+  // depth counter keeps the highlight steady until the pointer truly leaves.
+  const depth = useRef(0);
+
+  const hasFiles = (e: DragEvent) =>
+    Array.from(e.dataTransfer?.types ?? []).includes("Files");
+
+  const onDragEnter = useCallback(
+    (e: DragEvent) => {
+      if (disabled || !hasFiles(e)) return;
+      e.preventDefault();
+      depth.current += 1;
+      setIsDragging(true);
+    },
+    [disabled],
+  );
+
+  const onDragOver = useCallback(
+    (e: DragEvent) => {
+      if (disabled || !hasFiles(e)) return;
+      // Required so the element is recognised as a valid drop target.
+      e.preventDefault();
+    },
+    [disabled],
+  );
+
+  const onDragLeave = useCallback((e: DragEvent) => {
+    e.preventDefault();
+    depth.current = Math.max(0, depth.current - 1);
+    if (depth.current === 0) setIsDragging(false);
+  }, []);
+
+  const onDrop = useCallback(
+    (e: DragEvent) => {
+      depth.current = 0;
+      setIsDragging(false);
+      if (disabled) return;
+      e.preventDefault();
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      if (files.length === 0) return;
+      onFiles(multiple ? files : files.slice(0, 1));
+    },
+    [disabled, multiple, onFiles],
+  );
+
+  return {
+    isDragging,
+    dropProps: { onDragEnter, onDragOver, onDragLeave, onDrop },
+  };
+}


### PR DESCRIPTION
## Summary

Three UX-safety improvements requested together, all on the frontend:

### 1. Modals/popups only close via the "X"
A backdrop click or **Esc** no longer dismisses a modal — only the X button (or an explicit in-form Cancel/action) closes it, so a half-typed form can't be lost to a stray click outside the box. Body-scroll-lock is preserved.

- `components/primitives/modal.tsx` — the shared base used by ~20 page-level modals (admin reject/deactivate/erase, doctor & healthworker availability "copy week", healthworker queue add/cancel, sysadmin "add account", rubber-stamp preview/edit, etc.) — all inherit the change.
- `components/primitives/camera-capture-modal.tsx`, `qr-capture-modal.tsx`, `image-preview-modal.tsx` — same treatment.
- `meeting-modal.tsx` already closed only via its X — left as-is.

### 2. Drag-and-drop on every upload
New reusable `lib/use-file-drop.ts` hook (dragenter/leave depth counter, file-type filtering, single vs. multiple). Wired into all three upload surfaces with a drag-highlight state — **additive**; existing click-to-pick, camera, and phone-QR paths are untouched:

- `components/admin/rubber-stamp-uploader.tsx` — drop onto the empty dropzone or the captured-stamp card.
- `components/doctor/signature-input.tsx` — drop onto the Upload tab's zone.
- `components/healthworker/attachments-panel.tsx` — drop multiple photos anywhere on the card (disabled when locked/uploading).

### 3. Confirm-password on every change form
Audited all password inputs. Five forms already had a confirm field (sysadmin add-account, sysadmin/self account section, doctor-onboarding rotation, initial setup ×2). The only gap was the **doctor form** (admin create/edit **and** self-onboarding):

- `components/admin/doctor-form.tsx` — added a "Confirm password" field + trim-aware match validation that fires whenever a password is being set, including edit-mode rotation. (Login is the only remaining single password input — correct, it's not a change.)

## Merge / conflict check
Merged latest `origin/main` (7 commits, incl. doctor-form e-signature replace/clear, rubber-stamp output-size validation, and auth-field trimming). Auto-merged with no conflicts; verified main's `acceptEdited`/size-validation and QR error messages are preserved alongside these changes, and that the password-confirm match check trims consistently with main's new trimming behavior.

## Verification
- `tsc --noEmit` ✓
- `next lint` ✓ (only a pre-existing unrelated warning in `doctor-slot-picker.tsx`)
- `next build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)