### PR TITLE
fix(auth): stop wrong-role page flash and gate all routes behind login

### DIFF
--- a/frontend/src/app/(app)/layout.tsx
+++ b/frontend/src/app/(app)/layout.tsx
@@ -4,22 +4,7 @@ import { useEffect } from "react";
 import { usePathname, useRouter } from "next/navigation";
 
 import { Topbar } from "@/components/shell/topbar";
-import { ROLE_HOMES, useAuth } from "@/lib/auth";
-
-// URL segment → role mapping. The sys-admin role uses a "sysadmin" URL segment
-// (no hyphen) because Next dynamic-route filenames forbid hyphens and we keep
-// segment <-> role 1:1 for the layout guard.
-const SEGMENT_TO_ROLE = {
-  admin: "admin",
-  doctor: "doctor",
-  healthworker: "healthworker",
-  sysadmin: "sys-admin",
-} as const;
-type SectionSegment = keyof typeof SEGMENT_TO_ROLE;
-
-function isSectionSegment(s: string | undefined): s is SectionSegment {
-  return s !== undefined && s in SEGMENT_TO_ROLE;
-}
+import { ROLE_HOMES, SEGMENT_TO_ROLE, useAuth } from "@/lib/auth";
 
 // Auth gate + role guard for everything under (app). If you're at /admin/* but
 // signed in as a doctor, you're redirected to /doctor (server-side ACLs are still
@@ -29,19 +14,32 @@ export default function AppLayout({ children }: { children: React.ReactNode }) {
   const pathname = usePathname() ?? "/";
   const { session, loading } = useAuth();
 
+  // The first path segment names the role section. If it's a section that
+  // isn't this user's, they're on a page they don't belong on. Computed during
+  // render (not just in the effect) so we can gate the children below.
+  const segment = pathname.split("/").filter(Boolean)[0];
+  const roleMismatch =
+    !!session &&
+    segment !== undefined &&
+    segment in SEGMENT_TO_ROLE &&
+    SEGMENT_TO_ROLE[segment] !== session.role;
+
   useEffect(() => {
     if (loading) return;
     if (!session) {
       router.replace(`/login?next=${encodeURIComponent(pathname)}`);
       return;
     }
-    const segment = pathname.split("/").filter(Boolean)[0];
-    if (isSectionSegment(segment) && SEGMENT_TO_ROLE[segment] !== session.role) {
+    if (roleMismatch) {
       router.replace(ROLE_HOMES[session.role]);
     }
-  }, [session, loading, router, pathname]);
+  }, [session, loading, router, pathname, roleMismatch]);
 
-  if (loading || !session) {
+  // Gate rendering until we know the user belongs on this exact path. Without
+  // the `roleMismatch` check the wrong-role page renders for one frame before
+  // the effect above redirects — the "doctor's page flashes when a health
+  // worker signs in" bug.
+  if (loading || !session || roleMismatch) {
     return (
       <main className="flex min-h-screen items-center justify-center">
         <span className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--muted-foreground)]">

--- a/frontend/src/app/login/page.tsx
+++ b/frontend/src/app/login/page.tsx
@@ -9,7 +9,7 @@ import { Button } from "@/components/primitives/button";
 import { Input, Label } from "@/components/primitives/input";
 import { SectionLabel } from "@/components/primitives/section-label";
 import { LoginHeroGraphic } from "@/components/marketing/login-hero-graphic";
-import { ROLE_HOMES, useAuth, type Role } from "@/lib/auth";
+import { resolveLoginRedirect, useAuth, type Role } from "@/lib/auth";
 import { ApiError, api } from "@/lib/api";
 import { explainError } from "@/lib/error-codes";
 import { fadeIn, fadeInUp, staggerTight } from "@/lib/motion";
@@ -56,7 +56,7 @@ function LoginScreen() {
   // page that would immediately 409 setup_required.
   useEffect(() => {
     if (loading || !session || !setupLoaded || uninitialized) return;
-    const next = search.get("next") || ROLE_HOMES[session.role];
+    const next = resolveLoginRedirect(search.get("next"), session.role);
     router.replace(next);
   }, [session, loading, setupLoaded, uninitialized, router, search]);
 
@@ -73,7 +73,7 @@ function LoginScreen() {
         body: { username: username.trim(), password: password.trim() },
       });
       login({ username: res.username, role: res.role, expiresAt: res.expiresAt });
-      const next = search.get("next") || ROLE_HOMES[res.role];
+      const next = resolveLoginRedirect(search.get("next"), res.role);
       router.replace(next);
     } catch (err) {
       // Backend returns a stable `invalid_credentials` code regardless of

--- a/frontend/src/app/not-found.tsx
+++ b/frontend/src/app/not-found.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+
+import { ROLE_HOMES, useAuth } from "@/lib/auth";
+
+// Global not-found boundary for any unmatched URL. Next renders this for paths
+// with no matching route (and for explicit notFound() calls) inside the root
+// layout, so the auth context is available. Behaviour follows the app's rule
+// that every /* path stays behind the wall:
+//   - signed out → bounce to /login
+//   - signed in  → show a real 404 with a way back to their dashboard
+export default function NotFound() {
+  const router = useRouter();
+  const { session, loading } = useAuth();
+
+  useEffect(() => {
+    if (loading) return;
+    if (!session) router.replace("/login");
+  }, [session, loading, router]);
+
+  // While auth resolves, or while we're redirecting a signed-out visitor, show
+  // the same minimal spinner the guards use rather than flashing the 404.
+  if (loading || !session) {
+    return (
+      <main className="flex min-h-screen items-center justify-center">
+        <span className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+          Loading…
+        </span>
+      </main>
+    );
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 px-6 text-center">
+      <div className="flex flex-col gap-2">
+        <span className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--muted-foreground)]">
+          Error 404
+        </span>
+        <h1 className="font-display text-4xl tracking-[-0.02em] sm:text-5xl">Page not found</h1>
+        <p className="max-w-md text-[var(--muted-foreground)]">
+          The page you&apos;re looking for doesn&apos;t exist or has moved.
+        </p>
+      </div>
+      <Link
+        href={ROLE_HOMES[session.role]}
+        className="font-mono text-xs uppercase tracking-[0.15em] text-[var(--accent)] hover:underline"
+      >
+        ← Back to your dashboard
+      </Link>
+    </main>
+  );
+}

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -2,6 +2,7 @@
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
 import { useRouter } from "next/navigation";
+import { useQueryClient } from "@tanstack/react-query";
 
 import { api } from "./api";
 
@@ -29,6 +30,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   // Rehydrate from the cookie on mount. /auth/me returns 200 when the
   // session cookie is still valid; the api() wrapper turns a 401 into a
@@ -86,8 +88,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       // still drop the session.
     }
     setSession(null);
+    // Drop every cached query so the next user never sees the previous one's
+    // data flash before their own request resolves. The cache is keyed by
+    // endpoint, not by user, so a stale `/doctors/me` would otherwise paint
+    // for a frame after a different person signs in.
+    queryClient.clear();
     router.replace("/login");
-  }, [router]);
+  }, [router, queryClient]);
 
   return (
     <AuthContext.Provider value={{ session, loading, login, logout }}>{children}</AuthContext.Provider>
@@ -106,3 +113,29 @@ export const ROLE_HOMES: Record<Role, string> = {
   healthworker: "/healthworker/appointments",
   "sys-admin": "/sysadmin",
 };
+
+// First URL segment → role. The sys-admin role uses the "sysadmin" segment
+// (no hyphen) because Next route folders can't contain hyphens. Single source
+// of truth for the (app) layout guard and the login redirect.
+export const SEGMENT_TO_ROLE: Record<string, Role> = {
+  admin: "admin",
+  doctor: "doctor",
+  healthworker: "healthworker",
+  sysadmin: "sys-admin",
+};
+
+// Does this path live in the given role's section? Every protected page lives
+// under a role segment, so a path that doesn't match the user's role is one
+// they don't belong on.
+export function pathMatchesRole(pathname: string, role: Role): boolean {
+  const segment = pathname.split("/").filter(Boolean)[0];
+  return segment !== undefined && SEGMENT_TO_ROLE[segment] === role;
+}
+
+// Where to send a user after sign-in: honour an explicit `?next=` only when it
+// belongs to their own role, otherwise fall back to their home. This stops a
+// stale or cross-role `next` (e.g. a doctor's 401 left `?next=/doctor`, then a
+// health worker signs in) from bouncing them through another role's page.
+export function resolveLoginRedirect(nextParam: string | null, role: Role): string {
+  return nextParam && pathMatchesRole(nextParam, role) ? nextParam : ROLE_HOMES[role];
+}


### PR DESCRIPTION
## Problem

After signing out and back in as a different role, the previous user's page rendered for a split second before redirecting — e.g. log in as doctor, log out, log in as health worker → the doctor page flashes, then jumps to the health-worker home. Separately, unmatched URLs (e.g. `/random`) fell through to Next's built-in 404, which is **not** auth-gated, so a signed-out visitor could land on a 404 instead of the login page.

## Root cause

The role guard in `(app)/layout.tsx` ran inside a `useEffect`, which fires *after* the first paint. So any path whose role segment didn't match the session rendered that role's page for one frame before the effect's `router.replace()`. The most common trigger: a doctor's 401/visit leaves `?next=/doctor` on the login URL, and the login page honored `next` blindly — so a health worker signing in was sent to `/doctor`, flashed it, then bounced to `/healthworker/appointments`. A stale React-Query cache (keyed by endpoint, not user) could add a data flash on top.

## Changes

- **`(app)/layout.tsx`** — compute `roleMismatch` during render and add it to the render gate, so the wrong-role page **never paints** (shows the Loading screen, then redirects).
- **`login/page.tsx`** — new `resolveLoginRedirect()` honors `?next=` **only** when it belongs to the signing-in user's role; otherwise falls back to their home. Applied to both the on-submit and already-signed-in redirect paths.
- **`lib/auth.tsx`** — `queryClient.clear()` on logout so the next user never sees the previous one's cached data. `SEGMENT_TO_ROLE` moves here as the single source of truth (was duplicated in the layout), plus `pathMatchesRole()` / `resolveLoginRedirect()` helpers.
- **`app/not-found.tsx`** (new) — global not-found boundary: signed-out visitors → `/login` (every `/*` stays behind the wall); signed-in users → a real 404 with a link back to their dashboard.

## Verification

- `tsc --noEmit`: clean on all changed files (the one remaining error, `qrcode.react`, pre-exists on `main` and is unrelated).
- `next lint` on the four changed files: no warnings or errors.
- Merged latest `origin/main` (preconsult/vitals + backend changes) — no file overlap, no conflicts.

Note: not yet exercised live in a browser; verification was static + flow tracing. Happy to run `next dev` and click through doctor→logout→healthworker if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)