### PR TITLE
ops(deployment): pin prod images to 0.7.0

### DIFF
--- a/deployment/terraform.tfvars
+++ b/deployment/terraform.tfvars
@@ -13,5 +13,5 @@
 # NOTE: the referenced tag must already exist in GHCR before you apply, or the
 # Ansible `docker compose pull` step fails. For a new semver, push the git tag and
 # wait for the "Build Docker images" workflow to go green first.
-docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.5.1"
-docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.5.1"
+docker_image_backend  = "ghcr.io/sight-hkust/haputele-backend:0.7.0"
+docker_image_frontend = "ghcr.io/sight-hkust/haputele-frontend:0.7.0"


### PR DESCRIPTION
Bumps the production image pins in `deployment/terraform.tfvars` from **0.5.1 → 0.7.0** (the `v0.7.0` release tag).

## What's in 0.7.0 (since the 0.5.1 pin)
- feat(preconsult): meaningful, well-indicated vitals validation errors
- feat(sysadmin): editable clinic identity and system defaults
- feat(ux): confirm-password, drag-and-drop uploads, click-safe modals
- fix(api): serialise validator ValueErrors in the 422 handler
- fix(preconsult): don't flash the consent notice while it's still loading
- fix(auth): stop wrong-role page flash; gate all unmatched routes behind login (#40)
- plus the doctor-invite-visibility / e-signature / whitespace-stripping fixes from v0.6.0

## Merge / deploy order
1. Wait for the **Build Docker images** workflow on tag `v0.7.0` to go green — the `:0.7.0` images must exist in GHCR before apply, or the Ansible `docker compose pull` step fails.
2. Merge this PR.
3. Run the **Deployment** workflow with `intent=apply` (no `image_tag` override needed — it reads this pin).

Rollback: `git revert` this commit, or use the Deployment workflow's `image_tag` input for an immediate commit-free rollback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)