### PR TITLE
fix(appointments): prevent double-booking on concurrent create requests

### DIFF
--- a/backend/app/routers/appointments.py
+++ b/backend/app/routers/appointments.py
@@ -3,6 +3,7 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
@@ -82,6 +83,25 @@ def _slot_taken(db: Session, doctor_id: int, scheduled_at: datetime, exclude_id:
     return db.scalar(stmt) is not None
 
 
+def _on_slot_conflict(db: Session, doctor_id: int, scheduled_at: datetime) -> None:
+    """Turn a lost concurrent-insert race into the same 409 the pre-check
+    raises, rather than a raw 500.
+
+    `create_appointment` / `book_queue_entry` pre-check the slot with
+    `_slot_taken`, but two requests can both see it free and then race on
+    the partial unique index `appointments_doctor_slot_unique` (doctor_id,
+    scheduled_at WHERE status <> 'cancelled'). The loser's commit raises an
+    IntegrityError; rolling back the poisoned session and re-confirming the
+    slot is now taken surfaces the same `doctor_slot_taken` conflict the
+    client already understands. The DB index is the ultimate source of
+    truth here — this guard just makes its verdict legible.
+    """
+    db.rollback()
+    if _slot_taken(db, doctor_id, scheduled_at):
+        raise conflict("doctor_slot_taken")
+    raise  # unexpected unique violation — let it surface, don't swallow it.
+
+
 @router.post("", response_model=AppointmentOut, status_code=status.HTTP_201_CREATED,
              dependencies=[Depends(require_role("healthworker"))])
 def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)) -> AppointmentOut:
@@ -101,7 +121,14 @@ def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)
         status="scheduled",
     )
     db.add(appt)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # A concurrent request won the slot race on the partial unique
+        # index. Surface the same 409 the pre-check would, so a double
+        # click (or rapid concurrent POSTs) can't strand a second row or
+        # leak a 500.
+        _on_slot_conflict(db, payload.doctorId, payload.scheduledAt)
     db.refresh(appt)
     return AppointmentOut.model_validate(appt)
 

--- a/backend/app/routers/consultations.py
+++ b/backend/app/routers/consultations.py
@@ -2,13 +2,14 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, forbidden, not_found, unprocessable
 from ..dateutils import snap_to_monday
 from ..models import Appointment, Consultation, Doctor, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _on_slot_conflict, _slot_taken
 from ..schemas import (
     AppointmentOut,
     ConsultationOut,
@@ -159,7 +160,14 @@ def submit_consultation(cid: int, payload: ConsultationSubmitIn, db: Session = D
             status="scheduled",
         )
         db.add(follow_up_appt)
-        db.flush()
+        try:
+            db.flush()
+        except IntegrityError:
+            # A concurrent request won the slot race on the partial unique
+            # index before this flush. Nothing else has been mutated yet in
+            # this submit, so rolling back is clean and the doctor gets the
+            # same 409 the pre-check would raise.
+            _on_slot_conflict(db, appt.doctor_id, payload.followUp.scheduledAt)
         c.follow_up_date = payload.followUp.scheduledAt.date()
         c.follow_up_appointment_id = follow_up_appt.appointment_id
     elif isinstance(payload.followUp, FollowUpWeeks):

--- a/backend/app/routers/queue.py
+++ b/backend/app/routers/queue.py
@@ -3,13 +3,14 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dateutils import snap_to_monday
 from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, not_found, unprocessable
 from ..models import Appointment, Doctor, Patient, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _on_slot_conflict, _slot_taken
 from ..schemas import (
     AppointmentOut,
     QueueBookIn,
@@ -179,12 +180,24 @@ def book_queue_entry(qid: int, payload: QueueBookIn, db: Session = Depends(db_de
         status="scheduled",
     )
     db.add(appt)
-    db.flush()  # get appt.appointment_id without committing
+    try:
+        db.flush()  # get appt.appointment_id without committing
+    except IntegrityError:
+        # A concurrent booking won the slot race on the partial unique
+        # index before this flush. The queue entry stays 'pending' so the
+        # healthworker can retry — only the appointment insert is rolled
+        # back, and the loser gets the same 409 the pre-check would raise.
+        _on_slot_conflict(db, payload.doctorId, payload.scheduledAt)
 
     entry.status = "booked"
     entry.appointment_id = appt.appointment_id
     entry.booked_at = datetime.now(timezone.utc)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError:
+        # The commit is the other race window (a row committed between our
+        # flush and commit). Same resolution: surface doctor_slot_taken.
+        _on_slot_conflict(db, payload.doctorId, payload.scheduledAt)
     db.refresh(entry)
     db.refresh(appt)
     return {

--- a/backend/tests/test_appointment_double_booking.py
+++ b/backend/tests/test_appointment_double_booking.py
@@ -1,0 +1,143 @@
+"""Regression: concurrent appointment creation must not double-book.
+
+`_slot_taken` is a pre-check — two POST /appointments (the "Book
+appointment" double-click, or rapid concurrent requests) can both see the
+slot free and then race on the partial unique index
+`appointments_doctor_slot_unique` (doctor_id, scheduled_at WHERE
+status <> 'cancelled'). The loser's commit used to surface as an unhandled
+500; the appointment-create / queue-book / consultation-followup sites now
+catch the IntegrityError, roll back, and raise the same 409
+`doctor_slot_taken` the pre-check would. This test drives that race
+deterministically and asserts exactly one booking survives.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+@pytest.fixture
+def hw_client(client, healthworker_account):
+    """TestClient already logged in as the healthworker."""
+    username, password = healthworker_account
+    r = client.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return client
+
+
+@pytest.fixture
+def bookable_slot(seeded_doctor):
+    """A patient + a fixed future slot, shared by the racing requests.
+
+    Returns (patient_id, doctor_id, scheduledAt ISO string).
+    """
+    from app.database import SessionLocal
+    from app.models import Patient
+
+    db = SessionLocal()
+    try:
+        patient = Patient(given_name="Race", family_name="Patient", gender="female")
+        db.add(patient)
+        db.commit()
+        slot = (datetime.now(timezone.utc) + timedelta(days=2)).replace(
+            microsecond=0
+        ).isoformat()
+        return patient.patient_id, seeded_doctor.doctor_id, slot
+    finally:
+        db.close()
+
+
+def _create_appointment(client, patient_id, doctor_id, slot):
+    """Fire one POST /appointments. Returns the response."""
+    return client.post(
+        "/appointments",
+        json={
+            "patientId": patient_id,
+            "doctorId": doctor_id,
+            "scheduledAt": slot,
+        },
+        headers=_csrf(client),
+    )
+
+
+def _active_appointments_for_slot(doctor_id: int, slot: str) -> int:
+    from app.database import SessionLocal
+    from app.models import Appointment
+
+    db = SessionLocal()
+    try:
+        rows = db.scalars(
+            Appointment.__table__.select().where(
+                Appointment.doctor_id == doctor_id,
+                Appointment.scheduled_at == datetime.fromisoformat(slot),
+                Appointment.status != "cancelled",
+            )
+        ).all()
+        return len(rows)
+    finally:
+        db.close()
+
+
+def test_concurrent_create_does_not_double_book(hw_client, bookable_slot):
+    """Two simultaneous POSTs to the same slot: one 201, one 409, one row.
+
+    Uses a fresh TestClient per thread so each races on its own DB session
+    against the shared partial unique index.
+    """
+    patient_id, doctor_id, slot = bookable_slot
+
+    def fire(_):
+        # Reuse the same live app instance via a fresh TestClient so the
+        # CSPI/cookie state is per-thread (httpx TestClient is not
+        # thread-safe to share).
+        from fastapi.testclient import TestClient
+        import app.main as app_main
+        with TestClient(app_main.app) as c:
+            # Log in as the healthworker inside this thread's client.
+            r = c.post(
+                "/auth/login",
+                json={"username": "test_hw", "password": "TestHW-Password-123"},
+            )
+            assert r.status_code == 200, r.text
+            return _create_appointment(c, patient_id, doctor_id, slot)
+
+    with ThreadPoolExecutor(max_workers=2) as ex:
+        responses = list(ex.map(fire, range(2)))
+
+    statuses = sorted(r.status_code for r in responses)
+    assert statuses == [201, 409], [
+        f"expected one 201 and one 409, got {statuses}: "
+        f"{[r.text for r in responses]}"
+    ]
+    # The losing request reports the friendly conflict, not a raw 500.
+    loser = next(r for r in responses if r.status_code == 409)
+    assert loser.json()["detail"]["error"] == "doctor_slot_taken"
+
+    # Exactly one appointment row exists for that active slot — no double-booking.
+    assert _active_appointments_for_slot(doctor_id, slot) == 1
+
+
+def test_sequential_slot_taken_conflict_still_works(hw_client, bookable_slot):
+    """Sanity guard: the existing pre-check conflict path is unchanged.
+
+    Booking a slot twice sequentially must keep returning 409
+    doctor_slot_taken (the optimistic check), not regress to a 500.
+    """
+    patient_id, doctor_id, slot = bookable_slot
+
+    first = _create_appointment(hw_client, patient_id, doctor_id, slot)
+    assert first.status_code == 201, first.text
+
+    second = _create_appointment(hw_client, patient_id, doctor_id, slot)
+    assert second.status_code == 409, second.text
+    assert second.json()["detail"]["error"] == "doctor_slot_taken"
+
+    assert _active_appointments_for_slot(doctor_id, slot) == 1

--- a/backend/tests/test_slot_conflict_helper.py
+++ b/backend/tests/test_slot_conflict_helper.py
@@ -1,0 +1,55 @@
+"""Unit tests for the `_on_slot_conflict` race-loser helper.
+
+These don't need Postgres: they drive the helper with a fake session to
+prove the lost-race verdict is converted into the friendly 409
+`doctor_slot_taken` (matching the optimistic pre-check) and that an
+unexpected unique violation is re-raised rather than masked.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from app.routers.appointments import _on_slot_conflict
+from app.errors import conflict  # noqa: F401  (ensures import path stands)
+
+
+class _FakeSession:
+    """Minimal stand-in: records rollback(), and answers scalar() with a
+    configured value (True → slot is taken, False → nothing matches)."""
+
+    def __init__(self, scalar_value):
+        self.scalar_value = scalar_value
+        self.rolled_back = 0
+
+    def rollback(self):
+        self.rolled_back += 1
+
+    def scalar(self, _stmt):
+        return self.scalar_value
+
+
+def test_lost_race_raises_doctor_slot_taken():
+    db = _FakeSession(scalar_value=True)  # the winning row is now visible
+    slot = datetime(2026, 7, 20, 9, 0, tzinfo=timezone.utc)
+    with pytest.raises(Exception) as ei:
+        _on_slot_conflict(db, doctor_id=1, scheduled_at=slot)
+    # FastAPI's HTTPException carries the 409 + code.
+    assert getattr(ei.value, "status_code", None) == 409
+    assert ei.value.detail["error"] == "doctor_slot_taken"
+    assert db.rolled_back == 1  # the poisoned session was cleaned before the re-check
+
+
+def test_unexpected_unique_violation_is_not_masked():
+    # _slot_taken says the slot is NOT actually taken — so the IntegrityError
+    # we caught was something else. Re-raise so it surfaces honestly.
+    db = _FakeSession(scalar_value=False)
+    slot = datetime(2026, 7, 20, 9, 0, tzinfo=timezone.utc)
+    # The helper re-raises the original IntegrityError from the caller's
+    # frame; here there's no active exception, so it raises RuntimeError
+    # ("No active exception to re-raise"). Either way it propagates — never
+    # returns and never raises the friendly conflict for an absent row.
+    with pytest.raises(Exception):
+        _on_slot_conflict(db, doctor_id=1, scheduled_at=slot)
+    assert db.rolled_back == 1


### PR DESCRIPTION
# fix(appointments): prevent double-booking on concurrent create requests

## Summary

Double-clicking "Book appointment" (or firing rapid concurrent `POST /appointments`)
could race the server's optimistic slot check and collide on the existing
partial unique index `appointments_doctor_slot_unique`. The losing request
raised an unhandled `IntegrityError` (a 500 instead of a clean conflict), and
under some interleavings a duplicate could slip through before the index
rejected it. This PR makes the appointment-creation paths idempotent at the DB
level by catching that unique-violation and surfacing it as the same
`409 doctor_slot_taken` the optimistic pre-check already returns — no second
row, no leaked 500.

Fixes #75

## Changes

- `backend/app/routers/appointments.py` — added `_on_slot_conflict(db, doctor_id, scheduled_at)`, a shared helper that rolls back the poisoned session, re-confirms the slot is now taken, and raises `conflict("doctor_slot_taken")` (re-raising the original `IntegrityError` if the slot is *not* actually taken, so an unexpected violation is never masked). `create_appointment` wraps its `db.commit()` in `try/except IntegrityError` and routes the loser through this helper.
- `backend/app/routers/queue.py` — `book_queue_entry` wraps both `db.flush()` (where it first emits the insert) and `db.commit()` (the narrow race between flush and commit) in the same `try/except`, so the queue entry stays `pending` (retryable) and the loser gets the friendly 409 instead of a 500.
- `backend/app/routers/consultations.py` — the consultation follow-up appointment insert (`db.flush()`) is wrapped too; nothing else in the submit is mutated before that flush, so a lost race aborts cleanly with `doctor_slot_taken` and the consultation is left un-finalized for retry.

No frontend change: the "Book appointment" button already disables itself via the React Query `isPending` state, which also re-enables on error so the user can retry. The remaining exploitable gap was the server-side TOCTOU between the `_slot_taken` pre-check and the insert, which is what this PR closes.

The partial unique index already exists (added in the initial schema, migration `0001`), so **no migration is needed** — the DB was already the source of truth; this PR only makes its verdict legible instead of an unhandled 500.

## Testing

- Static: `python3 -m py_compile` on all three edited routers and both new test files → `COMPILE_OK` (all modules import-parse correctly, including the new `from sqlalchemy.exc import IntegrityError` and the shared `_on_slot_conflict` import).
- New tests added (follow the repo's existing `backend/tests/` pytest + real-Postgres convention from `docs/DEVELOPMENT.md`):
  - `backend/tests/test_slot_conflict_helper.py` — a Postgres-free unit test for the `_on_slot_conflict` helper: asserts a lost race raises `409 doctor_slot_taken` (with the session rolled back), and that an unexpected violation is re-raised rather than swallowed.
  - `backend/tests/test_appointment_double_booking.py` — a concurrent regression test that fires two simultaneous `POST /appointments` (one thread each, independent sessions) at the same slot and asserts exactly one `201`, exactly one `409 doctor_slot_taken`, and exactly one active appointment row in the DB — plus a sequential sanity check that the pre-check conflict path still returns the friendly 409.

These tests require a reachable Postgres (the documented `docker compose up -d db` then `DATABASE_URL=… pytest backend/tests/` flow; the conftest auto-skips when Postgres is not reachable, as noted in `backend/tests/conftest.py`). The sandboxed test runner provided to me cannot allocate user namespaces in this environment (AppArmor restricts unprivileged userns, so `bubblewrap`/`sandbox-run` cannot start here), and no Postgres was reachable on this host, so I could not execute the live pytest run myself — verification here is limited to the static compile check above. The maintainers' standard `docker compose up -d db` + `pytest backend/tests/test_appointment_double_booking.py backend/tests/test_slot_conflict_helper.py` will run both new tests against a real DB.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
