### PR TITLE
fix(build): pin shell scripts to LF so Windows checkouts can boot the api

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Shell scripts run inside Linux containers and in CI. They must keep LF
+# endings — a CRLF checkout on Windows appends \r to the shebang, so the
+# kernel looks for an interpreter literally named "/bin/sh\r" and the
+# container dies with "exec ./entrypoint.sh: no such file or directory".
+*.sh text eol=lf


### PR DESCRIPTION
## The problem

Git's Windows default (`core.autocrlf=true`) rewrites LF to CRLF on checkout. A shell script carried into a Linux container then has `#!/bin/sh\r` as its shebang, so the kernel looks for an interpreter literally named `/bin/sh\r`.

The api container dies in a restart loop:

```
exec ./entrypoint.sh: no such file or directory
exec ./entrypoint.sh: no such file or directory
...
```

That message is doubly confusing — the path it can't find is the **interpreter**, not the script. `entrypoint.sh` is present and executable the whole time.

**Every Windows clone hits this.** `db`, `rustfs` and `frontend` come up healthy, the api never does, and nothing in the error names the real cause.

## Scope

Both tracked shell scripts are affected:

| File | Impact |
|---|---|
| `backend/entrypoint.sh` | **Blocks the api from starting at all** |
| `deployment/scripts/ansible-vault-encrypt.sh` | Same exposure on the Ansible path (CI checks out LF, so not currently failing) |

## Why `.gitattributes` and not a local config change

`.gitattributes` ships with the repository and **overrides each contributor's local `core.autocrlf`**. A `git config core.autocrlf input` would fix one machine and leave the next person to clone on Windows to rediscover the bug from scratch.

Scoped to `*.sh` deliberately rather than a repo-wide `* text=auto eol=lf` — only the shell scripts are broken, and repo-wide normalisation would rewrite every tracked file in everyone's working copy for no benefit.

## Verification

Reproduced and fixed on a Windows 11 machine:

```
$ file backend/entrypoint.sh
backend/entrypoint.sh: POSIX shell script, ASCII text executable, with CRLF line terminators   # before
backend/entrypoint.sh: POSIX shell script, ASCII text executable                               # after
```

After converting the working-tree copies, the api boots cleanly through its full sequence — waits for Postgres, runs `alembic upgrade head`, prints the setup-token banner, and starts Uvicorn.

Five lines, one file, no code touched. Suggest merging this ahead of any larger review — it unblocks Windows contributors immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
close #109 