### PR TITLE
fix(preconsult): limit temperature precision to 1 decimal place follow up of the issue #50

### DIFF
--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -605,7 +605,9 @@ class PreconsultIn(BaseModel):
     sysBp: Optional[int] = Field(default=None, ge=50, le=300)           # mmHg
     diaBp: Optional[int] = Field(default=None, ge=30, le=200)           # mmHg
     pulse: Optional[int] = Field(default=None, ge=20, le=300)           # bpm
-    temperature: Optional[Decimal] = Field(default=None, ge=30, le=45)  # °C
+    temperature: Optional[Decimal] = Field(
+        default=None, ge=30, le=45, decimal_places=1
+    )  # °C
     primaryComplaint: Optional[str] = Field(default=None, max_length=2000)
 
     @model_validator(mode="after")

--- a/backend/tests/test_preconsult_validation.py
+++ b/backend/tests/test_preconsult_validation.py
@@ -109,6 +109,19 @@ def test_out_of_range_vital_is_rejected_with_field_location(hw_client, ready_app
     assert _preconsult(appt_id) is None
 
 
+def test_temperature_with_more_than_one_decimal_place_is_rejected(hw_client, ready_appointment):
+    appt_id = ready_appointment
+    r = hw_client.put(
+        f"/appointments/{appt_id}/preconsult",
+        json={"temperature": 36.75},
+        headers=_csrf(hw_client),
+    )
+    assert r.status_code == 422, r.text
+    locs = [e["loc"][-1] for e in r.json()["detail"]["errors"]]
+    assert "temperature" in locs
+    assert _preconsult(appt_id) is None
+
+
 def test_diastolic_at_or_above_systolic_is_rejected(hw_client, ready_appointment):
     appt_id = ready_appointment
     r = hw_client.put(

--- a/frontend/src/lib/vitals.ts
+++ b/frontend/src/lib/vitals.ts
@@ -109,6 +109,7 @@ export function parseVitalsValidationError(err: ApiError | null | undefined): Pa
   const rawErrors = (err.detail?.errors ?? []) as Array<{
     loc?: unknown[];
     msg?: string;
+    type?: string;
   }>;
   if (!Array.isArray(rawErrors) || rawErrors.length === 0) {
     return { fieldErrors: {}, formError: null };
@@ -124,7 +125,13 @@ export function parseVitalsValidationError(err: ApiError | null | undefined): Pa
 
     if (KNOWN_FIELDS.has(last)) {
       const field = last as VitalField;
-      fieldErrors[field] = outOfRangeMessage(field);
+      // Pydantic tags each error with a `type`; a precision failure
+      // (decimal_max_places) is not a range problem, so give it the same
+      // message the client-side validator uses instead of "between X and Y".
+      fieldErrors[field] =
+        String(e.type ?? "") === "decimal_max_places"
+          ? decimalPlacesMessage(field)
+          : outOfRangeMessage(field);
       continue;
     }
 
@@ -144,4 +151,9 @@ export function parseVitalsValidationError(err: ApiError | null | undefined): Pa
 function outOfRangeMessage(field: VitalField): string {
   const { label, unit, min, max } = VITALS_BOUNDS[field];
   return `${label} looks off — enter a value between ${min} and ${max} ${unit}. Double-check the reading.`;
+}
+
+function decimalPlacesMessage(field: VitalField): string {
+  const { label, maxDecimalPlaces } = VITALS_BOUNDS[field];
+  return `${label} can have at most ${maxDecimalPlaces ?? 1} decimal place.`;
 }

--- a/frontend/src/lib/vitals.ts
+++ b/frontend/src/lib/vitals.ts
@@ -16,6 +16,8 @@ type Bound = {
   max: number;
   /** true → whole numbers only (everything except temperature). */
   integer: boolean;
+  /** Maximum fractional digits for decimal measurements. */
+  maxDecimalPlaces?: number;
 };
 
 export const VITALS_BOUNDS: Record<VitalField, Bound> = {
@@ -24,7 +26,14 @@ export const VITALS_BOUNDS: Record<VitalField, Bound> = {
   sysBp: { label: "Systolic BP", unit: "mmHg", min: 50, max: 300, integer: true },
   diaBp: { label: "Diastolic BP", unit: "mmHg", min: 30, max: 200, integer: true },
   pulse: { label: "Pulse", unit: "bpm", min: 20, max: 300, integer: true },
-  temperature: { label: "Temperature", unit: "°C", min: 30, max: 45, integer: false },
+  temperature: {
+    label: "Temperature",
+    unit: "°C",
+    min: 30,
+    max: 45,
+    integer: false,
+    maxDecimalPlaces: 1,
+  },
 };
 
 export const PRIMARY_COMPLAINT_MAX = 2000;
@@ -43,9 +52,13 @@ export function validateVital(field: VitalField, raw: string): string | null {
     return `${VITALS_BOUNDS[field].label} must be a number.`;
   }
 
-  const { label, unit, min, max, integer } = VITALS_BOUNDS[field];
+  const { label, unit, min, max, integer, maxDecimalPlaces } = VITALS_BOUNDS[field];
   if (integer && !Number.isInteger(num)) {
     return `${label} must be a whole number.`;
+  }
+  const decimalPart = value.split(".")[1] ?? "";
+  if (!integer && maxDecimalPlaces !== undefined && decimalPart.length > maxDecimalPlaces) {
+    return `${label} can have at most ${maxDecimalPlaces} decimal place.`;
   }
   if (num < min || num > max) {
     return `${label} looks off — enter a value between ${min} and ${max} ${unit}. Double-check the reading.`;


### PR DESCRIPTION
## Summary
- Reject preconsult temperature values with more than 1 decimal place (e.g. 36.75) via `decimal_places=1` on `PreconsultIn.temperature.`
- Mirror the same rule in the frontend (`frontend/src/lib/vitals.ts`) so the form catches it before submission

## Testing
- Added `test_temperature_with_more_than_one_decimal_place_is_rejected` (expects 422)
- Verified in the running compose stack: 36.7 accepted, 36.75 rejected with `decimal_max_places`

Closes #50 