### PR TITLE
test(infra): refuse to run the suite against a non-test database

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -9,8 +9,12 @@ that talks to a real Postgres. The expectation is that the operator runs:
 
 The conftest creates the `haputele_test` database (idempotent), runs all
 Alembic migrations against it, and wipes setup-relevant tables before
-each test. It does NOT wipe `db_data` of the dev compose DB — they're
-different schemas.
+each test.
+
+That wipe is destructive and unconditional, so the target is checked first:
+the suite REFUSES to run unless the database name ends in `_test`. See
+dbguard.py — the check exists because this once ran against the dev database
+and deleted every account in it.
 
 If DATABASE_URL is not set, conftest defaults to the URL above. If the
 Postgres at that URL is not reachable, the tests are skipped (so a `make
@@ -27,6 +31,8 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import pytest
+
+from tests.dbguard import assert_test_database
 
 # Session cookies are Secure by default — browsers (and httpx) refuse to
 # send them over plain HTTP. TestClient mounts the app at `http://testserver`,
@@ -46,6 +52,12 @@ def _ensure_database_url() -> str:
         url = _DEFAULT_TEST_URL
         os.environ["DATABASE_URL"] = url
     return url
+
+
+# Guard at import time, not inside a fixture: this runs before collection, so
+# a fixture-ordering change or a test that bypasses `_bootstrap_test_db` can
+# never reach the wipe with a live database selected.
+assert_test_database(_ensure_database_url())
 
 
 def _pg_reachable(url: str) -> bool:

--- a/backend/tests/dbguard.py
+++ b/backend/tests/dbguard.py
@@ -1,0 +1,94 @@
+"""Refuse to run the suite against anything but a test database.
+
+`conftest.py`'s `_wipe_setup_state` fixture is `autouse=True`: before every
+single test it deletes every row from accounts, doctor, patients, consultations
+and appointments — disabling the `consultations_locked_guard` and
+`appointments_locked_guard` immutability triggers in order to do it — and
+resets `system_config` to uninitialized.
+
+That is correct behaviour for a test database and catastrophic for any other.
+The suite picks its target from `DATABASE_URL`, and the api container exports
+`postgresql+psycopg2://hapu:hapu@db:5432/haputele` (docker-compose.yml), so
+`docker compose exec api pytest tests/` aimed the wipe at the dev database and
+destroyed every account in it on 2026-08-05.
+
+So the target is checked, once, at conftest import time — before collection,
+before any fixture, where nothing can skip it. The rule is a name ending in
+`_test`, which both the unset-DATABASE_URL default (`haputele_test`) and CI
+(.github/workflows/docker.yml) already satisfy.
+
+There is deliberately no override. An escape hatch for this would be a flag
+whose only purpose is to re-enable deleting the data we are protecting, and a
+flag that exists can be left set by a stray export. A database that needs to
+run this suite can be renamed.
+
+The scratch databases in test_migration_0017_username_whitespace.py
+(`haputele_mig_<uuid>`) are unaffected: they are created by that module and
+handed to alembic through a subprocess environment, and never become the base
+URL this guard inspects.
+"""
+from __future__ import annotations
+
+from urllib.parse import urlparse
+
+import pytest
+
+
+TEST_DB_SUFFIX = "_test"
+
+_REFUSAL = """\
+
+  ============================ REFUSING TO RUN ============================
+  {name!r} is not a test database.
+
+  This suite DELETES every row in accounts, doctor, patients, consultations
+  and appointments before EACH test, and resets system_config. It runs only
+  against a database whose name ends in {suffix!r}.
+
+  Point it somewhere disposable:
+
+      DATABASE_URL=postgresql+psycopg2://hapu:hapu@localhost:5432/haputele_test \\
+          pytest backend/tests/
+
+  Or leave DATABASE_URL unset — it defaults to that database.
+
+  Note that the api container exports DATABASE_URL for the *dev* database, so
+  `docker compose exec api pytest tests/` lands here. Override it explicitly:
+
+      docker compose exec \\
+          -e DATABASE_URL=postgresql+psycopg2://hapu:hapu@db:5432/haputele_test \\
+          api pytest tests/
+  =========================================================================
+"""
+
+
+def target_database(url: str) -> str:
+    """The database name a SQLAlchemy URL points at, or "" if it names none.
+
+    Strips the `+psycopg2` driver suffix so `urlparse` sees an ordinary
+    scheme, the same normalisation `conftest._pg_reachable` uses. A query
+    string (`?sslmode=require`) lands in `parsed.query`, not `parsed.path`,
+    so it can't be mistaken for part of the name.
+    """
+    parsed = urlparse(url.replace("+psycopg2", ""))
+    return (parsed.path or "").strip("/")
+
+
+def is_test_database(url: str) -> bool:
+    """True when `url` names a database this suite may destroy."""
+    return target_database(url).endswith(TEST_DB_SUFFIX)
+
+
+def assert_test_database(url: str) -> None:
+    """Raise `pytest.UsageError` unless `url` names a test database.
+
+    UsageError rather than a plain exception: pytest reports it as a usage
+    problem and exits before collecting anything, so no fixture — including
+    the wipe — ever gets the chance to run.
+    """
+    if is_test_database(url):
+        return
+    raise pytest.UsageError(
+        _REFUSAL.format(name=target_database(url) or "<no database in DATABASE_URL>",
+                        suffix=TEST_DB_SUFFIX)
+    )

--- a/backend/tests/test_db_guard.py
+++ b/backend/tests/test_db_guard.py
@@ -1,0 +1,68 @@
+"""The guard that stands between this suite and a live database.
+
+No database required — these are pure string tests. That matters: if this
+module needed Postgres it would be skipped on exactly the machines where a
+misconfigured DATABASE_URL does the damage.
+"""
+from __future__ import annotations
+
+import pytest
+
+from tests.dbguard import assert_test_database, is_test_database, target_database
+
+
+LOCAL_TEST_URL = "postgresql+psycopg2://hapu:hapu@localhost:5432/haputele_test"
+# The value docker-compose.yml exports into the api container. This exact URL
+# is what wiped the dev database on 2026-08-05.
+COMPOSE_DEV_URL = "postgresql+psycopg2://hapu:hapu@db:5432/haputele"
+
+
+def test_extracts_the_database_name():
+    assert target_database(LOCAL_TEST_URL) == "haputele_test"
+    assert target_database(COMPOSE_DEV_URL) == "haputele"
+
+
+def test_query_string_is_not_part_of_the_name():
+    url = "postgresql+psycopg2://hapu:hapu@db:5432/haputele_test?sslmode=require"
+    assert target_database(url) == "haputele_test"
+    assert is_test_database(url)
+
+
+def test_trailing_slash_is_not_part_of_the_name():
+    assert target_database(LOCAL_TEST_URL + "/") == "haputele_test"
+
+
+def test_accepts_a_test_database():
+    assert is_test_database(LOCAL_TEST_URL)
+    assert_test_database(LOCAL_TEST_URL)  # does not raise
+
+
+def test_rejects_the_dev_database():
+    assert not is_test_database(COMPOSE_DEV_URL)
+    with pytest.raises(pytest.UsageError) as exc:
+        assert_test_database(COMPOSE_DEV_URL)
+    assert "haputele" in str(exc.value)
+
+
+def test_rejects_a_url_naming_no_database():
+    url = "postgresql+psycopg2://hapu:hapu@db:5432/"
+    assert target_database(url) == ""
+    with pytest.raises(pytest.UsageError):
+        assert_test_database(url)
+
+
+def test_rejects_a_name_that_merely_contains_test():
+    # 'haputele_test_backup' is a real database someone would keep around;
+    # a substring match would have happily wiped it.
+    url = "postgresql+psycopg2://hapu:hapu@db:5432/haputele_test_backup"
+    with pytest.raises(pytest.UsageError):
+        assert_test_database(url)
+
+
+def test_refusal_message_names_the_database_and_the_fix():
+    with pytest.raises(pytest.UsageError) as exc:
+        assert_test_database(COMPOSE_DEV_URL)
+    message = str(exc.value)
+    assert "REFUSING TO RUN" in message
+    assert "'haputele'" in message
+    assert "haputele_test" in message


### PR DESCRIPTION
The backend test suite deletes every row in the database it is pointed at, and until now it never checked which database that was. On **2026-08-05** it was pointed at the dev database and deleted every account in it.

## The failure mode

`_wipe_setup_state` (`conftest.py`) is `autouse=True`, so before **each** test it runs:

```python
db.execute(text("DELETE FROM doctor"))
db.execute(text("DELETE FROM accounts"))
db.execute(text("UPDATE system_config SET initialized_at = NULL, ..."))
```

It also disables `consultations_locked_guard` and `appointments_locked_guard` — the triggers that make finalized records immutable — so it deletes through them. Correct for a test database; catastrophic anywhere else.

The target came from `DATABASE_URL`, unchecked:

```python
url = os.environ.get("DATABASE_URL")
if url is None:
    url = _DEFAULT_TEST_URL      # haputele_test — safe
    os.environ["DATABASE_URL"] = url
return url                       # otherwise: obey, unconditionally
```

Safe only when the variable happens to be unset. The api container exports `DATABASE_URL` for the **dev** database (`docker-compose.yml`), and it is the only place with the backend dependencies installed — so it is where the suite actually gets run. That made safety depend on retyping

```bash
docker compose exec -e DATABASE_URL=…@db:5432/haputele_test api pytest tests/
```

on every invocation, guarding a destructive default. The two commands differ by one flag and the dangerous one is shorter. It was left off once.

The docstring claimed *"It does NOT wipe `db_data` of the dev compose DB — they're different schemas."* True only when `DATABASE_URL` was unset, and enforced by nothing. Corrected.

## The fix

The database name must end in `_test`, checked at conftest **import** — before collection, so no fixture ordering can reach the wipe past it.

```
============================ REFUSING TO RUN ============================
'haputele' is not a test database.

This suite DELETES every row in accounts, doctor, patients, consultations
and appointments before EACH test, and resets system_config. It runs only
against a database whose name ends in '_test'.
...
```

**Deliberately no override.** An escape hatch here would be a flag whose only purpose is to re-enable deleting the data being protected, and a flag that exists can be left set by a stray export. A database that needs to run this suite can be renamed.

## Unaffected

- Unset `DATABASE_URL` — the default is already `haputele_test`
- CI — `.github/workflows/docker.yml` already sets `haputele_test`
- The `haputele_mig_<uuid>` scratch databases used by the migration tests, which never become the base URL this guard inspects

## Verification

- Dev `DATABASE_URL` → exits 4, **zero tests collected**, message names `'haputele'`
- `system_config.updated_at` in the dev database unchanged across that refusal — the run writes nothing
- Full suite against a `_test` database: **170 passed** (162 existing + 8 new)
- `DATABASE_URL` unset → guard accepts the default, then the pre-existing unreachable-Postgres skip applies

`test_db_guard.py` needs no database, deliberately: a test that required Postgres would be skipped on exactly the machines where a misconfigured `DATABASE_URL` does the damage.

Contributes to #102 — one safeguard toward *"production cannot be populated by demo seeds or test automation."* That issue stays open for object storage, email, secrets, logs and backups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

closes #115
