### PR TITLE
fix(frontend): render the 404 boundary for missing entities and malformed IDs in routes

### DIFF
--- a/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
+++ b/frontend/src/app/(app)/admin/doctors/[id]/page.tsx
@@ -25,13 +25,14 @@ import {
 } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
 import { doctorName, fmtDateTime } from "@/lib/format";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 
 export default function DoctorDetailPage() {
   const params = useParams<{ id: string }>();
-  const id = parseInt(params.id, 10);
+  const id = parseIdParam(params.id);
   const router = useRouter();
 
-  const doctor = useDoctor(Number.isFinite(id) ? id : null);
+  const doctor = useDoctor(id);
   const update = useUpdateDoctor(id);
   const deactivate = useDeactivateDoctor();
   const reissueInvite = useReissueDoctorInvite();
@@ -50,6 +51,7 @@ export default function DoctorDetailPage() {
   const [reapplyJustSent, setReapplyJustSent] = useState(false);
 
   if (doctor.error) {
+    throwNotFoundIf404(doctor.error);
     return (
       <div className="mx-auto max-w-4xl px-6 py-12">
         <ErrorBanner>{explainError(doctor.error.error)}</ErrorBanner>

--- a/frontend/src/app/(app)/doctor/appointments/[id]/page.tsx
+++ b/frontend/src/app/(app)/doctor/appointments/[id]/page.tsx
@@ -19,16 +19,18 @@ import { StatusBadge } from "@/components/primitives/status-badge";
 import { explainError } from "@/lib/error-codes";
 import { fmtDateTime } from "@/lib/format";
 import { useAppointment, useCreateOrGetDraft } from "@/lib/use-api";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 
 export default function DoctorAppointmentDetail() {
   const params = useParams<{ id: string }>();
-  const id = parseInt(params.id, 10);
+  const id = parseIdParam(params.id);
   const router = useRouter();
 
-  const apt = useAppointment(Number.isFinite(id) ? id : null);
+  const apt = useAppointment(id);
   const draft = useCreateOrGetDraft();
 
   if (apt.error) {
+    throwNotFoundIf404(apt.error);
     return (
       <div className="mx-auto max-w-5xl px-6 py-12">
         <ErrorBanner>{explainError(apt.error.error)}</ErrorBanner>

--- a/frontend/src/app/(app)/doctor/consultations/[id]/page.tsx
+++ b/frontend/src/app/(app)/doctor/consultations/[id]/page.tsx
@@ -11,11 +11,12 @@ import { Card } from "@/components/primitives/card";
 import { ErrorBanner } from "@/components/primitives/error-banner";
 import { useAppointment, useConsultation } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 
 export default function ConsultationPage() {
   const params = useParams<{ id: string }>();
-  const cid = parseInt(params.id, 10);
-  const consult = useConsultation(Number.isFinite(cid) ? cid : null);
+  const cid = parseIdParam(params.id);
+  const consult = useConsultation(cid);
   // Pull appointment via the consultation's appointmentId once we have it.
   const apt = useAppointment(consult.data?.appointmentId ?? null);
 
@@ -24,9 +25,20 @@ export default function ConsultationPage() {
   // error with cached data present must NOT unmount the flow — that would
   // wipe the doctor's stage, signature, and follow-up choice mid-consult.
   if (consult.error && !consult.data) {
+    throwNotFoundIf404(consult.error);
     return (
       <div className="mx-auto max-w-5xl px-6 py-12">
         <ErrorBanner>{explainError(consult.error.error)}</ErrorBanner>
+      </div>
+    );
+  }
+  // Same hard-fail for the linked appointment — without this branch an
+  // appointment fetch error left the page on the loading card forever.
+  if (apt.error && !apt.data) {
+    throwNotFoundIf404(apt.error);
+    return (
+      <div className="mx-auto max-w-5xl px-6 py-12">
+        <ErrorBanner>{explainError(apt.error.error)}</ErrorBanner>
       </div>
     );
   }

--- a/frontend/src/app/(app)/healthworker/appointments/[id]/page.tsx
+++ b/frontend/src/app/(app)/healthworker/appointments/[id]/page.tsx
@@ -11,17 +11,19 @@ import { PageHeader } from "@/components/primitives/page-header";
 import { useAppointment, useDoctorList } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
 import { doctorName } from "@/lib/format";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 
 export default function AppointmentDetailPage() {
   const params = useParams<{ id: string }>();
-  const id = parseInt(params.id, 10);
+  const id = parseIdParam(params.id);
 
-  const apt = useAppointment(Number.isFinite(id) ? id : null);
+  const apt = useAppointment(id);
   const doctors = useDoctorList();
 
   const doctor = doctors.data?.find((d) => d.id === apt.data?.appointment.doctorId);
 
   if (apt.error) {
+    throwNotFoundIf404(apt.error);
     return (
       <div className="mx-auto max-w-5xl px-6 py-12">
         <ErrorBanner>{explainError(apt.error.error)}</ErrorBanner>

--- a/frontend/src/app/(app)/healthworker/patients/[id]/page.tsx
+++ b/frontend/src/app/(app)/healthworker/patients/[id]/page.tsx
@@ -28,10 +28,11 @@ import {
 } from "@/lib/use-api";
 import { explainError } from "@/lib/error-codes";
 import { ageFromDob, fmtDate, fmtDateTime, fullName } from "@/lib/format";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 
 export default function PatientDetailPage() {
   const params = useParams<{ id: string }>();
-  const id = parseInt(params.id, 10);
+  const id = parseIdParam(params.id);
   const router = useRouter();
   const patientQ = usePatient(id);
   const historyQ = usePatientHistory(id);
@@ -49,6 +50,7 @@ export default function PatientDetailPage() {
     );
   }
   if (patientQ.error || !patientQ.data) {
+    throwNotFoundIf404(patientQ.error);
     return (
       <div className="mx-auto max-w-7xl px-6 py-12">
         <ErrorBanner>{explainError(patientQ.error?.error ?? "patient_not_found")}</ErrorBanner>

--- a/frontend/src/app/(app)/healthworker/patients/[id]/profile/page.tsx
+++ b/frontend/src/app/(app)/healthworker/patients/[id]/profile/page.tsx
@@ -10,17 +10,19 @@ import { ErrorBanner } from "@/components/primitives/error-banner";
 import { PageHeader } from "@/components/primitives/page-header";
 import { explainError } from "@/lib/error-codes";
 import { fullName } from "@/lib/format";
+import { parseIdParam, throwNotFoundIf404 } from "@/lib/not-found";
 import { usePatient, useUpsertProfile } from "@/lib/use-api";
 
 export default function PatientProfilePage() {
   const params = useParams<{ id: string }>();
-  const id = parseInt(params.id, 10);
+  const id = parseIdParam(params.id);
   const router = useRouter();
 
-  const patientQ = usePatient(Number.isFinite(id) ? id : null);
+  const patientQ = usePatient(id);
   const upsert = useUpsertProfile(id);
 
   if (patientQ.error) {
+    throwNotFoundIf404(patientQ.error);
     return (
       <div className="mx-auto max-w-4xl px-6 py-12">
         <ErrorBanner>{explainError(patientQ.error.error)}</ErrorBanner>

--- a/frontend/src/lib/not-found.ts
+++ b/frontend/src/lib/not-found.ts
@@ -1,0 +1,35 @@
+import { notFound } from "next/navigation";
+
+import { ApiError } from "./api";
+
+// Shared "this doesn't exist" handling for [id] detail pages, so entity-level
+// 404s render the same global not-found boundary as unmatched URLs
+// (src/app/not-found.tsx) instead of each page inventing its own banner —
+// or worse, hanging on a spinner forever (issue #52).
+//
+// Both helpers abort the render by throwing (notFound() returns `never`), so
+// call them before the JSX that assumes the data exists.
+
+// Digits only. Number() alone would accept "0x10" (→ 16) and "1e2" (→ 100),
+// silently loading a different record than the URL appears to name.
+const NUMERIC_ID = /^\d+$/;
+
+/** Parse a numeric route param, rendering the 404 boundary for anything that
+ *  isn't a positive integer id. Guards two failure modes: a malformed value
+ *  (e.g. /appointments/abc) used to produce NaN, which disabled the data query
+ *  and left the page loading forever; and an out-of-range value would have
+ *  been sent to the API as a float. */
+export function parseIdParam(raw: string | undefined): number {
+  if (!raw || !NUMERIC_ID.test(raw)) notFound();
+  const id = Number(raw);
+  if (!Number.isSafeInteger(id) || id <= 0) notFound();
+  return id;
+}
+
+/** Render the 404 boundary when a detail query failed because the entity
+ *  doesn't exist (HTTP 404). Returns normally for every other error (403,
+ *  5xx, network) so callers fall through to their inline error banner —
+ *  those mean something other than "not found". */
+export function throwNotFoundIf404(error: unknown): void {
+  if (error instanceof ApiError && error.status === 404) notFound();
+}


### PR DESCRIPTION
## Problem

Detail pages under `[id]` routes each invented their own handling for "this doesn't exist":

- **Missing entity** — `/healthworker/appointments/99999` matches a real route, so the global 404 boundary never fired. The page rendered its full chrome with only a bare inline error banner, while a misspelled URL like `/healthworker/appointmentzzz` showed the designed 404 page. Two different experiences for the same meaning.
- **Malformed id** — `/doctor/appointments/abc` parsed to `NaN`, which disabled the data query. No request was ever sent, so no error ever arrived and the page sat on a loading spinner forever. Four of six pages hung this way; a fifth happened to fall through to a banner.
- **Consultation page sub-case** — if the fetch of the *linked* appointment failed, there was no error branch at all: another path to an infinite spinner.

Affected every account type: health worker (appointments, patients, patient profile), doctor (appointments, consultations), admin (doctors).

## Solution

New `frontend/src/lib/not-found.ts` with two helpers, applied to all six `[id]` detail pages:

- **`parseIdParam()`** — validates the route param up front (digits only, safe positive integer) before any data fetching. Anything else renders the global not-found boundary immediately, so a malformed id can never leave the page hanging. Digit-strict on purpose: `Number()` alone would accept `0x10` (→ 16) and `1e2` (→ 100), silently loading a different record than the URL appears to name.
- **`throwNotFoundIf404()`** — an API 404 renders the same boundary as an unmatched URL. Every other error (403, 5xx, network) returns normally so callers keep their existing inline banner, since those mean something other than "not found".

Also added the missing error branch for the consultation page's linked appointment.

## Result

Every "doesn't exist" case now renders the same 404 page — with the role-aware "Back to your dashboard" link — for every account type, matching what unmatched URLs already did. All successful paths are unchanged.

## Routing standard confirmed

Audited every layout guard, role home, and redirect while here. The standard the code now follows consistently:

- **Signed out** → always redirect to `/login`, preserving `?next=` for paths that exist.
- **Signed in, doesn't exist** → 404 page (URL, entity, or malformed id alike).
- **Signed in, wrong role's section** → silent redirect to that user's own home.

Three asymmetries are deliberate and left as-is:

1. The 404 boundary drops `?next=` — the path doesn't exist, so preserving it would return the user to a 404 right after login.
2. Wrong-role access redirects silently rather than showing 404/403 — uniform across roles and doesn't leak what exists in other sections; server ACLs remain the source of truth.
3. Public token pages (`/capture/[token]`, `/doctor-onboarding/[token]`) show inline "invalid link" states instead of bouncing to login — their visitors are anonymous by design, so a login redirect would dead-end them.

## Testing

Manual, per role:

- `/healthworker/appointments/99999` → 404 page (was: inline banner)
- `/doctor/appointments/abc` → 404 page (was: infinite spinner)
- `/admin/doctors/99999`, `/healthworker/patients/abc` → 404 page
- Valid ids load unchanged; non-404 errors (403, network) still show the inline banner.

The repo has no frontend test infrastructure (no jest/vitest, zero test files), so verification is manual plus `tsc --noEmit` and `next lint`, both clean.

Refs #52

Close #52 