### PR TITLE
fix/login role home routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,8 +37,9 @@ yarn-error.log*
 .vscode/
 *.swp
 
-# Claude Code local state (worktrees, agent settings, runtime locks).
+# Agents local state (worktrees, agent settings, runtime locks).
 .claude/
+.codex/
 
 # Demo asset — real practitioner rubber-stamp PNG (PII). Keep out of repo.
 # Drop your own stamp at scripts/assets/doctor_stamp.png locally; the

--- a/frontend/src/lib/auth.tsx
+++ b/frontend/src/lib/auth.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react";
-import { useRouter } from "next/navigation";
-import { useQueryClient } from "@tanstack/react-query";
 
 import { api } from "./api";
 
@@ -29,8 +27,6 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [loading, setLoading] = useState(true);
-  const router = useRouter();
-  const queryClient = useQueryClient();
 
   // Rehydrate from the cookie on mount. /auth/me returns 200 when the
   // session cookie is still valid; the api() wrapper turns a 401 into a
@@ -83,18 +79,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       await api("/auth/logout", { method: "POST", skipAuthRedirect: true });
     } catch {
-      // Best-effort: if the backend rejects (e.g. session already
-      // expired), the cookies may not be cleared — but the UI should
-      // still drop the session.
+      // Best-effort: leave this document even if the session already expired
+      // or the backend is unavailable. Auth bootstrap will recheck any cookie.
     }
-    setSession(null);
-    // Drop every cached query so the next user never sees the previous one's
-    // data flash before their own request resolves. The cache is keyed by
-    // endpoint, not by user, so a stale `/doctors/me` would otherwise paint
-    // for a frame after a different person signs in.
-    queryClient.clear();
-    router.replace("/login");
-  }, [router, queryClient]);
+    // Keep the React session intact until this document unloads. Clearing it
+    // first lets the still-mounted protected layout turn the old pathname into
+    // `/login?next=...`, causing the next same-role login to resume that route.
+    // Replacing the document also discards every in-memory cached query.
+    window.location.replace("/login");
+  }, []);
 
   return (
     <AuthContext.Provider value={{ session, loading, login, logout }}>{children}</AuthContext.Provider>
@@ -128,6 +121,7 @@ export const SEGMENT_TO_ROLE: Record<string, Role> = {
 // under a role segment, so a path that doesn't match the user's role is one
 // they don't belong on.
 export function pathMatchesRole(pathname: string, role: Role): boolean {
+  if (!pathname.startsWith("/") || pathname.startsWith("//")) return false;
   const segment = pathname.split("/").filter(Boolean)[0];
   return segment !== undefined && SEGMENT_TO_ROLE[segment] === role;
 }


### PR DESCRIPTION
## Summary

Fixes a routing issue found while verifying the previous-session data-flash fix.

After signing out from a nested page such as `/doctor/profile`, the app could generate `/login?next=/doctor/profile`. The same user or another doctor would then return to that old route after login. No previous-user data appeared, but the route was incorrectly retained across sessions.

## Root cause

Logout cleared the React session while the protected page was still mounted. The route guard treated this as an unauthenticated visit and generated `next` from the old pathname.

## Intended behavior

After explicit logout, every login starts at the role home:

- Admin: `/admin`
- Doctor: `/doctor`
- Health worker: `/healthworker/appointments`
- System admin: `/sysadmin`

This applies to the same account, another same-role account, and cross-role login.

`login?next=` remains supported for legitimate cases such as bookmarked protected pages and session-expiry reauthentication. Invalid or non-local `next` values fall back to the role home.

## Changes

- Use a full-page replacement during explicit logout, preventing the old route from becoming `next`.
- Discard in-memory cached data with the replaced document.
- Restrict `next` to local absolute paths.

## Verification

- [x] Typecheck
- [x] Production build
- [x] Test logout from nested pages for all four roles.
- [x] Test same-account, same-role, and cross-role login.
- [x] Confirm bookmarked routes and expired sessions still resume correctly.
- [x] Confirm no previous-account data appears.

Closes #51 