### PR TITLE
fix(ui): reject e/+/- in number inputs instead of dropping the value

### DIFF
--- a/frontend/src/components/primitives/input.tsx
+++ b/frontend/src/components/primitives/input.tsx
@@ -3,11 +3,24 @@ import { cn } from "@/lib/cn";
 
 export type InputProps = InputHTMLAttributes<HTMLInputElement>;
 
+// A native number input happily accepts these as you type, but then reports
+// value="" for the resulting invalid state — so "36e" reads back as blank and
+// the entry is discarded with nothing to show the user it was lost. Nothing we
+// ask for in numbers (vitals, follow-up weeks) is negative or exponential, so
+// refuse the keys outright rather than let a silent drop through.
+const BLOCKED_NUMBER_KEYS = new Set(["e", "E", "+", "-"]);
+
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type = "text", ...props }, ref) => (
+  ({ className, type = "text", onKeyDown, ...props }, ref) => (
     <input
       ref={ref}
       type={type}
+      onKeyDown={(event) => {
+        if (type === "number" && BLOCKED_NUMBER_KEYS.has(event.key)) {
+          event.preventDefault();
+        }
+        onKeyDown?.(event);
+      }}
       className={cn(
         "flex h-12 w-full rounded-xl border border-[var(--border)] bg-transparent px-4 py-2 text-sm",
         "text-[var(--foreground)] placeholder:text-[var(--muted-foreground)]/60",


### PR DESCRIPTION
Closes #119

### Problem

A native `<input type="number">` accepts `e`, `E`, `+` and `-` as you type, then reports `value === ""` for the resulting invalid state. The typed reading is discarded with nothing shown to the user.

There are exactly two `type="number"` inputs in the frontend, and both were affected:

| Location | Account | Symptom |
| --- | --- | --- |
| `healthworker/vitals-form.tsx` (preconsult vitals) | Health worker | `validateVital` saw `""`, treated the vital as "not measured", submitted it as `null` — no error |
| `doctor/consultation-flow.tsx` (follow-up "in N weeks") | Doctor | `Number("") \|\| 0` snapped the follow-up silently to `0` weeks |

### Fix

One guard in the shared `Input` primitive (`frontend/src/components/primitives/input.tsx`), scoped to `type === "number"`, blocking those keys on keydown and still delegating to any caller-supplied `onKeyDown` (RHF registers one on `sysBp`). Fixing the primitive rather than the two call sites means number inputs added later are covered by default.

Out of scope, deliberately:
- `.` stays allowed — temperature uses `step="0.1"`.
- Paste isn't intercepted: `1e5` pastes as a real `100000`, which the existing range check in `lib/vitals.ts` rejects visibly.
- No backend change; bounds in `backend/app/schemas.py` remain the final authority.

### Verification

- `npm run lint` clean (the two `doctor-slot-picker` warnings are pre-existing).
- `npx tsc --noEmit` reports only stale `.next/types` errors for pages belonging to another branch; nothing in `src/`.
- No frontend test script exists, so no suite was run.
- Browser check pending — note that `localhost:3000` is the compose container, so it needs `docker compose up -d --build frontend` to pick this up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
