### PR TITLE
fix(ui): label the lifestyle occupation field "Occupation", not "Job"

### DIFF
--- a/frontend/src/components/doctor/patient-summary.tsx
+++ b/frontend/src/components/doctor/patient-summary.tsx
@@ -238,7 +238,7 @@ function ProfileFacts({ profile }: { profile: Profile }) {
   const lifestyle: string[] = [];
   if (profile.lifestyle.smoking) lifestyle.push(`Smoking · ${profile.lifestyle.smoking}`);
   if (profile.lifestyle.alcohol) lifestyle.push(`Alcohol · ${profile.lifestyle.alcohol}`);
-  if (profile.lifestyle.occupation) lifestyle.push(`Job · ${profile.lifestyle.occupation}`);
+  if (profile.lifestyle.occupation) lifestyle.push(`Occupation · ${profile.lifestyle.occupation}`);
   if (lifestyle.length) sections.push({ title: "Lifestyle", items: lifestyle });
 
   if (!sections.length) {

--- a/frontend/src/components/healthworker/profile-summary.tsx
+++ b/frontend/src/components/healthworker/profile-summary.tsx
@@ -97,7 +97,7 @@ export function ProfileSummary({ profile, editHref }: { profile: Profile | null;
             <ul className="flex flex-col gap-1 text-sm text-[var(--muted-foreground)]">
               {profile.lifestyle.smoking && <li>Smoking · {profile.lifestyle.smoking}</li>}
               {profile.lifestyle.alcohol && <li>Alcohol · {profile.lifestyle.alcohol}</li>}
-              {profile.lifestyle.occupation && <li>Job · {profile.lifestyle.occupation}</li>}
+              {profile.lifestyle.occupation && <li>Occupation · {profile.lifestyle.occupation}</li>}
               {profile.lifestyle.physicalActivity && (
                 <li>Activity · {physicalActivityLabel(profile.lifestyle.physicalActivity)}</li>
               )}


### PR DESCRIPTION
Closes #68

## Problem

The patient's occupation was labelled inconsistently depending on where you looked. The intake form calls it **Occupation**, and the API type is `occupation` — but both read-only summary views rendered it as `Job ·`.

| Surface | Before | After |
|---|---|---|
| Intake form (`profile-form.tsx:332`) | Occupation | Occupation (unchanged) |
| Health worker profile summary | Job · | **Occupation ·** |
| Doctor consultation panel | Job · | **Occupation ·** |

## The change

Two display strings, in the two places that render the lifestyle block alongside its `Smoking ·` / `Alcohol ·` siblings:

- `frontend/src/components/doctor/patient-summary.tsx:241`
- `frontend/src/components/healthworker/profile-summary.tsx:100`

No schema, type, or API change — the underlying property stays `profile.lifestyle.occupation`. Nothing in the test suite referenced the literal `Job`, and no i18n layer wraps these strings.

`id="ls-job"` on the form input is left alone: it's an internal DOM id, not user-visible, and its `<Label>` already reads "Occupation". Keeps the diff scoped to the reported bug.

## Testing

- `npx tsc --noEmit` — no errors in `src/`
- `npm run lint` — passes (the 2 warnings are pre-existing, in the untouched `doctor-slot-picker.tsx`)
- `grep -rn "Job ·" frontend/src` — no matches remain

Static verification only; I did not run the app to view the rendered panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
