### PR TITLE
fix(ui): label appointment statuses by what is actually outstanding

### DIFF
--- a/frontend/src/components/healthworker/cockpit.tsx
+++ b/frontend/src/components/healthworker/cockpit.tsx
@@ -54,7 +54,9 @@ export function AppointmentCockpit({ data }: { data: AppointmentDetail }) {
   const sessionConsented = !!(sessionConsent?.agreed && !sessionConsent.revokedAt);
   // Distinguish "not consented" from "still loading the consent status" — a
   // consent_pending appointment always already has consent, so we mustn't flash
-  // the "record consent first" notice before the query resolves.
+  // the "record consent first" notice before the query resolves. (The status is
+  // named for the step it enters, not the one just finished; `statusLabel` in
+  // lib/format.ts is what keeps that off the badge.)
   const sessionConsentResolved = !sessionConsentQ.isPending;
 
   return (

--- a/frontend/src/components/healthworker/patient-context.tsx
+++ b/frontend/src/components/healthworker/patient-context.tsx
@@ -6,7 +6,7 @@ import Link from "next/link";
 
 import { Button } from "@/components/primitives/button";
 import { useAppointmentList, useQueueList } from "@/lib/use-api";
-import { fmtDateTime, fmtTargetWeek } from "@/lib/format";
+import { fmtDateTime, fmtTargetWeek, statusLabel } from "@/lib/format";
 import type { QueueEntry } from "@/types/api";
 
 // Beneath the patient picker on the booking form: surface what's already
@@ -65,7 +65,7 @@ export function PatientContext({
                   <Clock className="h-3 w-3" />
                   {fmtDateTime(a.scheduledAt)} · {a.doctorName}
                   <span className="font-mono uppercase tracking-[0.1em] text-[10px] text-amber-700">
-                    ({a.status.replace(/_/g, " ")})
+                    ({statusLabel(a.status)})
                   </span>
                 </Link>
               </li>

--- a/frontend/src/components/primitives/status-badge.tsx
+++ b/frontend/src/components/primitives/status-badge.tsx
@@ -1,4 +1,5 @@
 import { cn } from "@/lib/cn";
+import { statusLabel } from "@/lib/format";
 
 // Maps the §11 appointment state machine to visual treatment.
 // `in_progress` is the only state that pulses — it's the "alive" state.
@@ -36,7 +37,7 @@ export function StatusBadge({ status, className }: { status: string; className?:
     >
       <span className={cn("h-1.5 w-1.5 rounded-full", style.dot, style.pulse && "animate-pulse-soft")} aria-hidden />
       <span className={cn("font-mono text-[11px] uppercase tracking-[0.12em]", style.text)}>
-        {status.replace(/_/g, " ")}
+        {statusLabel(status)}
       </span>
     </span>
   );

--- a/frontend/src/lib/format.ts
+++ b/frontend/src/lib/format.ts
@@ -86,8 +86,23 @@ export function doctorName(d: { givenName: string; familyName: string }): string
   return `Dr. ${d.givenName} ${d.familyName}`.trim();
 }
 
+// The §11 status values are named for the step being entered, not the step just
+// completed — `consent_pending` is reached *after* consent is captured, and
+// `data_collection` *after* the vitals are saved. Rendering them raw told the
+// health worker the opposite of the truth, so never show the raw value: map it
+// to whatever is actually outstanding.
+const STATUS_LABELS: Record<string, string> = {
+  scheduled:       "Scheduled",
+  consent_pending: "Vitals pending",
+  data_collection: "Ready to start",
+  in_progress:     "In progress",
+  awaiting_notes:  "Awaiting notes",
+  completed:       "Completed",
+  cancelled:       "Cancelled",
+};
+
 export function statusLabel(s: string): string {
-  return s.replace(/_/g, " ");
+  return STATUS_LABELS[s] ?? s.replace(/_/g, " ");
 }
 
 // Queue target-date is stored as the Monday of the target week (snapped on


### PR DESCRIPTION
## Objective

A health worker who recorded the patient's session consent still saw the badge read **CONSENT PENDING**, until they *also* saved the preconsult vitals. It read as though the consent had silently failed to register.

This is a labelling bug, not a workflow gate — nothing blocks appointment creation, and consent does not wait on vitals. The dependency runs the other way (`upsert_preconsult` rejects vitals when there is no agreed consent, `backend/app/routers/preconsult.py:133-135`).

Two §11 status values are named for the step being *entered*, not the step just completed, and the badge rendered them raw:

| Status | Set when | Badge read | Now reads |
|---|---|---|---|
| `consent_pending` | consent has just been captured (`preconsult.py:92-93`) | CONSENT PENDING ❌ | **VITALS PENDING** |
| `data_collection` | vitals have just been saved (`preconsult.py:163-164`) | DATA COLLECTION ❌ | **READY TO START** |

`record_session_consent` writes `consent_pending` **only** when `payload.agreed` is true, and no endpoint revokes a *session* consent (only master consent). So the state strictly implies an agreed consent already exists — the badge asserted the opposite of the truth, 100% of the time it appeared.

## Approach

`frontend/src/lib/format.ts` already defined a `statusLabel()` helper that was never called — it was the intended seam for exactly this. Gave it a label map (keeping the underscore-strip as fallback) and routed the two raw renderers through it:

- `components/primitives/status-badge.tsx:39`
- `components/healthworker/patient-context.tsx:68`

Every other surface goes through `StatusBadge` and is fixed for free.

**Deliberately out of scope:** no DB migration and no backend change. Stored values and the `0001_initial_schema.py:139-142` CHECK constraint are untouched — renaming them would touch 9 code sites plus a backfill of live appointment rows, for no user-facing gain beyond what the map already delivers. All transitions and 409 guards are already correct. Badge colours are unchanged; they were never wrong.

## How to Test

1. `cd frontend && npm run typecheck && npm run lint && npm run build`
2. Bring the stack up (`docker compose up -d`) and sign in as a health worker.
3. Walk the repro:
   - Create an appointment → **SCHEDULED**
   - Record session consent (patient agreed, with signature) → **VITALS PENDING** *(was "CONSENT PENDING" — this is the bug)*
   - Save preconsult vitals → **READY TO START**
   - Start the meeting → **IN PROGRESS**; end it → **AWAITING NOTES**
4. Check the secondary surfaces: the appointment list on `healthworker/patients/[id]`, and the amber "upcoming appointments" strip rendered by `patient-context.tsx`.
5. Confirm no regression on `admin/doctors/[id]`, which reuses `StatusBadge` with `"completed"`/`"cancelled"` as pseudo-statuses for a doctor's active flag — these still render "Completed"/"Cancelled".

### Verification already run

`typecheck` clean, `lint` clean (the two remaining warnings are pre-existing in `doctor-slot-picker.tsx`), `build` passes, and the new labels are present in the shipped bundle.

The premise was also confirmed at runtime against the API on the test database — posting a consent to a `scheduled` appointment returned:

```
consent agreed      -> True
appointment status  -> consent_pending
vitals recorded     -> False
```

That was a throwaway characterisation test of backend behaviour this PR does not change, so it is not included in the diff. The frontend has no test framework, so there is no automated regression test to add here.

Closes #127 


After consent
<img width="1949" height="306" alt="image" src="https://github.com/user-attachments/assets/980eb13f-b3e3-4046-89d4-876bed1ecc13" />

After vitals
<img width="1952" height="306" alt="image" src="https://github.com/user-attachments/assets/c130a0b9-a4bc-4ebe-ae01-e07ec960a530" />

