### PR TITLE
fix(booking): hide elapsed slots and refuse to book in the past

### DIFF
--- a/backend/app/dateutils.py
+++ b/backend/app/dateutils.py
@@ -1,5 +1,28 @@
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta, timezone
 from typing import Optional
+
+
+# One slot width. The picker offers 15-min slots, and a slot stays bookable
+# while you are still inside it — a health worker who wants to start the
+# consultation right now should not be blocked by the clock having just
+# crossed the slot's start. So "in the past" means the whole slot has
+# elapsed, not merely that it started. Mirrored on the frontend as SLOT_MS
+# in `components/doctor/doctor-slot-picker.tsx`.
+#
+# The grace window doubles as slack for browser/server clock skew: the
+# client filters against its own clock, the server against its own, and
+# there is no server-time endpoint to reconcile them (see issue #81).
+BOOKING_GRACE = timedelta(minutes=15)
+
+
+def is_past_slot(scheduled_at: datetime, now: Optional[datetime] = None) -> bool:
+    """True when `scheduled_at`'s whole slot has already elapsed.
+
+    `scheduled_at` must be timezone-aware — every appointment schema that
+    reaches this runs `_require_aware` first, so a naive value is a bug in
+    the caller rather than something to paper over here.
+    """
+    return scheduled_at <= (now or datetime.now(timezone.utc)) - BOOKING_GRACE
 
 
 def snap_to_monday(d: Optional[date]) -> Optional[date]:

--- a/backend/app/routers/appointments.py
+++ b/backend/app/routers/appointments.py
@@ -6,8 +6,8 @@ from sqlalchemy import and_, select
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
-from ..errors import conflict, forbidden, not_found
-from ..dateutils import snap_to_monday
+from ..errors import conflict, forbidden, not_found, unprocessable
+from ..dateutils import is_past_slot, snap_to_monday
 from ..models import (
     Appointment,
     AppointmentAttachment,
@@ -82,6 +82,23 @@ def _slot_taken(db: Session, doctor_id: int, scheduled_at: datetime, exclude_id:
     return db.scalar(stmt) is not None
 
 
+def _reject_if_past(scheduled_at: datetime) -> None:
+    """Refuse to schedule an appointment whose slot has already elapsed.
+
+    The picker hides past slots, but the UI filters against the *browser*
+    clock and a tab left open overnight still offers stale chips — so the
+    server is the authority. `serverNow` goes in the body to make a skewed
+    client diagnosable from the response alone.
+    """
+    now = datetime.now(timezone.utc)
+    if is_past_slot(scheduled_at, now):
+        raise unprocessable(
+            "appointment_in_past",
+            scheduledAt=scheduled_at.isoformat(),
+            serverNow=now.isoformat(),
+        )
+
+
 @router.post("", response_model=AppointmentOut, status_code=status.HTTP_201_CREATED,
              dependencies=[Depends(require_role("healthworker"))])
 def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)) -> AppointmentOut:
@@ -91,6 +108,7 @@ def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)
     doctor = db.get(Doctor, payload.doctorId)
     if not doctor or not doctor.active:
         raise not_found("doctor_not_found")
+    _reject_if_past(payload.scheduledAt)
     if _slot_taken(db, payload.doctorId, payload.scheduledAt):
         raise conflict("doctor_slot_taken")
 
@@ -210,6 +228,11 @@ def update_appointment(appt_id: int, payload: AppointmentUpdate, db: Session = D
         d = db.get(Doctor, payload.doctorId)
         if not d or not d.active:
             raise not_found("doctor_not_found")
+    # Only vet the time when it is actually being moved — reassigning the
+    # doctor on an appointment that has already started is legitimate, and
+    # must not trip the past-slot guard on its unchanged scheduled_at.
+    if new_time != appt.scheduled_at:
+        _reject_if_past(new_time)
     if (new_doctor, new_time) != (appt.doctor_id, appt.scheduled_at):
         if _slot_taken(db, new_doctor, new_time, exclude_id=appt.appointment_id):
             raise conflict("doctor_slot_taken")

--- a/backend/app/routers/consultations.py
+++ b/backend/app/routers/consultations.py
@@ -8,7 +8,7 @@ from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, forbidden, not_found, unprocessable
 from ..dateutils import snap_to_monday
 from ..models import Appointment, Consultation, Doctor, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _reject_if_past, _slot_taken
 from ..schemas import (
     AppointmentOut,
     ConsultationOut,
@@ -150,6 +150,7 @@ def submit_consultation(cid: int, payload: ConsultationSubmitIn, db: Session = D
 
     if isinstance(payload.followUp, FollowUpAppointment):
         # Doctor books an exact follow-up appointment for themselves.
+        _reject_if_past(payload.followUp.scheduledAt)
         if _slot_taken(db, appt.doctor_id, payload.followUp.scheduledAt):
             raise conflict("doctor_slot_taken")
         follow_up_appt = Appointment(

--- a/backend/app/routers/queue.py
+++ b/backend/app/routers/queue.py
@@ -9,7 +9,7 @@ from ..dateutils import snap_to_monday
 from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, not_found, unprocessable
 from ..models import Appointment, Doctor, Patient, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _reject_if_past, _slot_taken
 from ..schemas import (
     AppointmentOut,
     QueueBookIn,
@@ -169,6 +169,7 @@ def book_queue_entry(qid: int, payload: QueueBookIn, db: Session = Depends(db_de
     doctor = db.get(Doctor, payload.doctorId)
     if not doctor or not doctor.active:
         raise not_found("doctor_not_found")
+    _reject_if_past(payload.scheduledAt)
     if _slot_taken(db, payload.doctorId, payload.scheduledAt):
         raise conflict("doctor_slot_taken")
 

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -507,10 +507,14 @@ class AppointmentCreate(BaseModel):
     doctorId: int
     scheduledAt: datetime
 
+    _aware = field_validator("scheduledAt")(_require_aware)
+
 
 class AppointmentUpdate(BaseModel):
     doctorId: Optional[int] = None
     scheduledAt: Optional[datetime] = None
+
+    _aware = field_validator("scheduledAt")(_require_aware)
 
 
 class RequeueOnCancel(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -152,10 +152,14 @@ def _wipe_setup_state():
         # deleted a few statements down.
         db.execute(text("UPDATE patients SET master_consent_id = NULL"))
         db.execute(text("DELETE FROM consents"))
+        # queue_entries.appointment_id is a plain FK (no ON DELETE), so a
+        # *booked* queue entry pins its appointment row. Wipe the queue first
+        # or the appointments delete below trips the constraint and every
+        # subsequent test in the session errors out on the dirty database.
+        db.execute(text("DELETE FROM queue_entries"))
         db.execute(text("ALTER TABLE appointments DISABLE TRIGGER appointments_locked_guard"))
         db.execute(text("DELETE FROM appointments"))
         db.execute(text("ALTER TABLE appointments ENABLE TRIGGER appointments_locked_guard"))
-        db.execute(text("DELETE FROM queue_entries"))
         db.execute(text("DELETE FROM doctor_availability"))
         db.execute(text("DELETE FROM profile"))
         db.execute(text("DELETE FROM patients"))

--- a/backend/tests/test_appointment_past_booking.py
+++ b/backend/tests/test_appointment_past_booking.py
@@ -1,0 +1,224 @@
+"""Issue #72: appointments must not be bookable at a time that has passed.
+
+The slot picker hides elapsed slots, but it filters against the *browser*
+clock — a tab left open overnight, or any direct API call, would otherwise
+still write a past appointment. These tests pin the server-side guard.
+
+The rule is deliberately not "scheduledAt < now": a slot stays bookable
+while you are still inside it, so a health worker can start the consultation
+right away. `BOOKING_GRACE` (one slot width) is that window.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app.dateutils import BOOKING_GRACE
+
+
+def _csrf(client) -> dict[str, str]:
+    token = client.cookies.get("csrf_token")
+    assert token
+    return {"X-CSRF-Token": token}
+
+
+@pytest.fixture
+def hw_client(client, healthworker_account):
+    """TestClient already logged in as the healthworker."""
+    username, password = healthworker_account
+    r = client.post("/auth/login", json={"username": username, "password": password})
+    assert r.status_code == 200, r.text
+    return client
+
+
+@pytest.fixture
+def patient_id(initialized_system) -> int:
+    from app.database import SessionLocal
+    from app.models import Patient
+
+    db = SessionLocal()
+    try:
+        p = Patient(given_name="Past", family_name="Booking", gender="female")
+        db.add(p)
+        db.commit()
+        return p.patient_id
+    finally:
+        db.close()
+
+
+def _iso(delta: timedelta) -> str:
+    return (datetime.now(timezone.utc) + delta).isoformat()
+
+
+def _create(hw_client, patient_id: int, doctor_id: int, scheduled_at: str):
+    return hw_client.post(
+        "/appointments",
+        json={"patientId": patient_id, "doctorId": doctor_id, "scheduledAt": scheduled_at},
+        headers=_csrf(hw_client),
+    )
+
+
+# ── POST /appointments ────────────────────────────────────────────────
+
+def test_create_rejects_fully_elapsed_slot(hw_client, patient_id, seeded_doctor):
+    r = _create(hw_client, patient_id, seeded_doctor.doctor_id, _iso(timedelta(hours=-2)))
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["error"] == "appointment_in_past"
+
+
+def test_create_allows_the_slot_currently_in_progress(hw_client, patient_id, seeded_doctor):
+    """Started 5 min ago, so the 15-min slot is still running — bookable."""
+    r = _create(hw_client, patient_id, seeded_doctor.doctor_id, _iso(timedelta(minutes=-5)))
+    assert r.status_code == 201, r.text
+
+
+def test_create_allows_future_slot(hw_client, patient_id, seeded_doctor):
+    r = _create(hw_client, patient_id, seeded_doctor.doctor_id, _iso(timedelta(hours=1)))
+    assert r.status_code == 201, r.text
+
+
+def test_create_boundary_is_exactly_one_slot_width(hw_client, patient_id, seeded_doctor):
+    """The instant the slot's own window closes, it stops being bookable."""
+    r = _create(
+        hw_client, patient_id, seeded_doctor.doctor_id,
+        _iso(-BOOKING_GRACE - timedelta(seconds=30)),
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["error"] == "appointment_in_past"
+
+
+def test_create_rejects_naive_timestamp_without_crashing(hw_client, patient_id, seeded_doctor):
+    """A naive scheduledAt must fail validation, not blow up the past-check."""
+    naive = datetime.now().replace(tzinfo=None).isoformat()
+    r = _create(hw_client, patient_id, seeded_doctor.doctor_id, naive)
+    assert r.status_code == 422, r.text
+    assert "timezone offset" in r.text
+
+
+# ── PATCH /appointments/{id} ──────────────────────────────────────────
+
+@pytest.fixture
+def past_appointment(patient_id, seeded_doctor) -> int:
+    """A still-live appointment whose scheduled time is already behind us."""
+    from app.database import SessionLocal
+    from app.models import Appointment
+
+    db = SessionLocal()
+    try:
+        appt = Appointment(
+            patient_id=patient_id,
+            doctor_id=seeded_doctor.doctor_id,
+            scheduled_at=datetime.now(timezone.utc) - timedelta(hours=3),
+            status="scheduled",
+        )
+        db.add(appt)
+        db.commit()
+        return appt.appointment_id
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def second_doctor(initialized_system) -> int:
+    import secrets
+
+    from app.database import SessionLocal
+    from app.models import Account, Doctor
+    from app.security import hash_password
+
+    db = SessionLocal()
+    try:
+        username = "dr_test_second"
+        db.add(Account(
+            username=username,
+            password=hash_password(secrets.token_urlsafe(32)),
+            role="doctor",
+        ))
+        db.add(Doctor(
+            username=username,
+            given_name="Second", family_name="Doctor",
+            contact="+94 11 000 0001",
+            email="dr_second@example.com",
+            slmc_registration_number="SLMC-TEST-2",
+            qualifications="MBBS",
+            practitioner_address="Test Address",
+            institute_name="Test Clinic",
+            institute_contact="+94 11 111 1112",
+            rubber_stamp_key="test/stub-stamp-key.png",
+            active=True,
+            approved_at=datetime.now(timezone.utc),
+        ))
+        db.commit()
+        return db.query(Doctor).filter_by(username=username).first().doctor_id
+    finally:
+        db.close()
+
+
+def test_patch_rejects_moving_time_into_the_past(hw_client, past_appointment):
+    r = hw_client.patch(
+        f"/appointments/{past_appointment}",
+        json={"scheduledAt": _iso(timedelta(hours=-2))},
+        headers=_csrf(hw_client),
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["error"] == "appointment_in_past"
+
+
+def test_patch_reassigns_doctor_on_a_past_appointment(
+    hw_client, past_appointment, second_doctor
+):
+    """Reassigning the doctor must not trip the guard on an unchanged time.
+
+    An appointment that has already started is exactly the one most likely
+    to need a doctor swap, so this path stays open.
+    """
+    r = hw_client.patch(
+        f"/appointments/{past_appointment}",
+        json={"doctorId": second_doctor},
+        headers=_csrf(hw_client),
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["doctorId"] == second_doctor
+
+
+# ── POST /queue/{qid}/book ────────────────────────────────────────────
+
+@pytest.fixture
+def pending_queue_entry(patient_id, healthworker_account) -> int:
+    from app.database import SessionLocal
+    from app.models import QueueEntry
+
+    db = SessionLocal()
+    try:
+        entry = QueueEntry(
+            patient_id=patient_id,
+            source="walk_in",
+            status="pending",
+            priority="routine",
+            created_by=healthworker_account[0],
+        )
+        db.add(entry)
+        db.commit()
+        return entry.queue_id
+    finally:
+        db.close()
+
+
+def test_queue_book_rejects_past_slot(hw_client, pending_queue_entry, seeded_doctor):
+    r = hw_client.post(
+        f"/queue/{pending_queue_entry}/book",
+        json={"doctorId": seeded_doctor.doctor_id, "scheduledAt": _iso(timedelta(hours=-2))},
+        headers=_csrf(hw_client),
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["detail"]["error"] == "appointment_in_past"
+
+
+def test_queue_book_allows_future_slot(hw_client, pending_queue_entry, seeded_doctor):
+    r = hw_client.post(
+        f"/queue/{pending_queue_entry}/book",
+        json={"doctorId": seeded_doctor.doctor_id, "scheduledAt": _iso(timedelta(hours=2))},
+        headers=_csrf(hw_client),
+    )
+    assert r.status_code == 200, r.text

--- a/frontend/src/components/doctor/doctor-slot-picker.tsx
+++ b/frontend/src/components/doctor/doctor-slot-picker.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { addDays, format, parseISO } from "date-fns";
 import { formatInTimeZone, fromZonedTime } from "date-fns-tz";
 import { AlertTriangle, ChevronLeft, ChevronRight, Loader2 } from "lucide-react";
@@ -10,7 +10,7 @@ import { Input, Label } from "@/components/primitives/input";
 import { Select } from "@/components/primitives/select";
 import { startOfWeekLocal } from "@/components/doctor/availability-grid-utils";
 import { useAppointmentList, useDoctorAvailability } from "@/lib/use-api";
-import { APP_TIMEZONE } from "@/lib/format";
+import { APP_TIMEZONE, appToday } from "@/lib/format";
 import { cn } from "@/lib/cn";
 
 // Slot picker for one doctor, one week at a time. Three controls in one frame:
@@ -27,8 +27,16 @@ import { cn } from "@/lib/cn";
 //
 // Already-booked slots (other appointments) never appear; the existing
 // _slot_taken backend check is the safety net.
+//
+// Elapsed slots never appear either. A slot counts as elapsed only once its
+// *whole* window has passed — the slot you are currently inside stays
+// bookable so a HW can start the consultation right away. The backend
+// mirrors this exactly (BOOKING_GRACE in app/dateutils.py) and is the
+// authority, since the filter here runs on the browser clock.
 
 const SLOT_MIN = 15;
+const SLOT_MS = SLOT_MIN * 60 * 1000;
+const NOW_TICK_MS = 60_000; // re-filter every minute so a long-open tab can't go stale
 const HORIZON_WEEKS = 12; // backend caps to 92 days; 12 weeks = 84 days
 const VISIBLE_HOUR_MIN = 7; // 07:00 — earliest "Or pick another time" slot
 const VISIBLE_HOUR_MAX = 20; // 20:00 — exclusive upper bound
@@ -71,6 +79,14 @@ export function DoctorSlotPicker({
     return defaultWeeksAhead;
   });
 
+  // Ticking "now" — a picker left open at 09:00 must stop offering 09:15
+  // once that slot has run out, without the user reloading.
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), NOW_TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
   const weekStartLocal = useMemo(
     () => startOfWeekLocal(addDays(new Date(), weeksAhead * 7)),
     [weeksAhead],
@@ -102,9 +118,12 @@ export function DoctorSlotPicker({
   );
 
   // Open slots inside declared availability for the visible week, by ymd.
-  const slotsByDay = useMemo(() => {
-    const result = new Map<string, Date[]>();
-    const slotMs = SLOT_MIN * 60 * 1000;
+  // `declaredDays` records which days had *any* declared window before the
+  // booked/elapsed filters ran, so an emptied-out day can say "no slots
+  // left" instead of wrongly claiming the doctor declared nothing.
+  const { byDay: slotsByDay, declaredDays } = useMemo(() => {
+    const byDay = new Map<string, Date[]>();
+    const declared = new Set<string>();
     const weekStartMs = parseISO(
       fromZonedTime(`${format(weekStartLocal, "yyyy-MM-dd")} 00:00:00`, APP_TIMEZONE).toISOString(),
     ).getTime();
@@ -115,18 +134,20 @@ export function DoctorSlotPicker({
       const wEnd = parseISO(w.endAt).getTime();
       const t0 = Math.max(wStart, weekStartMs);
       const tEnd = Math.min(wEnd, weekEndMs);
-      for (let t = t0; t + slotMs <= tEnd; t += slotMs) {
-        if (bookedAt.has(t)) continue;
+      for (let t = t0; t + SLOT_MS <= tEnd; t += SLOT_MS) {
         const slot = new Date(t);
         const ymd = formatInTimeZone(slot, APP_TIMEZONE, "yyyy-MM-dd");
-        const list = result.get(ymd) ?? [];
+        declared.add(ymd);
+        if (bookedAt.has(t)) continue;
+        if (t + SLOT_MS <= nowMs) continue; // whole slot elapsed
+        const list = byDay.get(ymd) ?? [];
         list.push(slot);
-        result.set(ymd, list);
+        byDay.set(ymd, list);
       }
     }
-    for (const list of result.values()) list.sort((a, b) => a.getTime() - b.getTime());
-    return result;
-  }, [allWindows, bookedAt, weekStartLocal]);
+    for (const list of byDay.values()) list.sort((a, b) => a.getTime() - b.getTime());
+    return { byDay, declaredDays: declared };
+  }, [allWindows, bookedAt, weekStartLocal, nowMs]);
 
   const days = useMemo(
     () =>
@@ -182,8 +203,9 @@ export function DoctorSlotPicker({
     onChange(`${date}T${t}`);
   };
 
-  // 15-min options for the "Or pick another time" select. Booked instants
-  // for the chosen date are flagged disabled.
+  // 15-min options for the "Or pick another time" select. Booked and
+  // elapsed instants for the chosen date are flagged disabled — kept in the
+  // list rather than dropped so the 07:00–20:00 rows stay in fixed positions.
   const customSlotOptions = useMemo(() => {
     if (!customDate) return [];
     const out: { value: string; label: string; disabled: boolean }[] = [];
@@ -193,11 +215,13 @@ export function DoctorSlotPicker({
       const hh = String(h).padStart(2, "0");
       const mm = String(min).padStart(2, "0");
       const ts = fromZonedTime(`${customDate} ${hh}:${mm}:00`, APP_TIMEZONE).getTime();
-      const disabled = bookedAt.has(ts);
-      out.push({ value: `${hh}:${mm}`, label: `${hh}:${mm}${disabled ? " · booked" : ""}`, disabled });
+      const booked = bookedAt.has(ts);
+      const past = ts + SLOT_MS <= nowMs;
+      const suffix = booked ? " · booked" : past ? " · past" : "";
+      out.push({ value: `${hh}:${mm}`, label: `${hh}:${mm}${suffix}`, disabled: booked || past });
     }
     return out;
-  }, [customDate, bookedAt]);
+  }, [customDate, bookedAt, nowMs]);
 
   const weekLabel =
     weeksAhead === 0 ? "This week" : weeksAhead === 1 ? "Next week" : `+${weeksAhead} weeks`;
@@ -265,7 +289,9 @@ export function DoctorSlotPicker({
                   </span>
                   {slots.length === 0 ? (
                     <span className="text-[11px] text-[var(--muted-foreground)]/70">
-                      No declared availability
+                      {declaredDays.has(d.ymd)
+                        ? "No slots remaining"
+                        : "No declared availability"}
                     </span>
                   ) : (
                     <div className="flex flex-wrap gap-1.5">
@@ -302,6 +328,7 @@ export function DoctorSlotPicker({
         <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
           <Input
             type="date"
+            min={appToday()}
             value={customDate}
             onChange={(e) => setCustomDate(e.target.value)}
           />

--- a/frontend/src/lib/error-codes.ts
+++ b/frontend/src/lib/error-codes.ts
@@ -9,6 +9,7 @@ const MESSAGES: Record<string, string> = {
   master_consent_not_agreed: "Master consent must be agreed before continuing.",
   session_consent_required: "Patient session consent is required first.",
   doctor_slot_taken: "That doctor already has another appointment at this time. Pick a different slot.",
+  appointment_in_past: "That time has already passed. Pick a later slot.",
   invalid_state: "This action isn't valid for the current appointment status.",
   livekit_not_configured: "Video calling isn't configured on this server — contact your administrator. The appointment is unaffected; retry once it's fixed.",
   consultation_locked: "This consultation has been signed and locked — no further edits.",


### PR DESCRIPTION
Closes #72.

## Problem

The slot picker generated every 15-min slot inside a doctor's declared availability and excluded exactly two things: slots outside that availability, and exact-instant collisions with an existing appointment. Nothing anywhere in the booking path compared against the clock — so booking at 14:00 still offered this morning's 07:00–13:45 as green, clickable chips, and the backend accepted them.

## The rule

A slot counts as elapsed only once its **whole** window has passed. The slot you are currently inside stays bookable, so a health worker can start the consultation right away. That one-slot window is `BOOKING_GRACE`.

## Frontend

`doctor-slot-picker.tsx` backs all three booking flows (HW manual, HW book-from-queue, doctor follow-up), so one fix covers them:

- Slots whose window has closed are dropped, against a `nowMs` that ticks every minute — a picker left open cannot go stale.
- A day emptied *only* by that filter now reads "No slots remaining" instead of falsely claiming "No declared availability".
- The "or pick another time" dropdown greys elapsed options as `· past` (kept in place rather than removed, so rows stay put), and the date input gained `min={appToday()}`.

## Backend

The UI filters on the **browser** clock, and a stale tab or a direct API call would otherwise still write a past appointment — so the server is the authority. 422 `appointment_in_past` on create, reschedule, queue-book, and consultation follow-up, with `serverNow` in the body so a skewed client is diagnosable from the response alone.

Reschedule only vets the time when it actually moves, so reassigning the doctor on an already-started appointment still works — that's the appointment most likely to need a swap.

`AppointmentCreate`/`AppointmentUpdate` were also missing the `_require_aware` validator their sibling schemas carry; without it a naive timestamp would have 500'd on the new comparison rather than failing validation.

## Separate commit: conftest FK ordering

`4903f5c` fixes a latent bug in `_wipe_setup_state`. `queue_entries.appointment_id` is a plain FK with no `ON DELETE`, so a *booked* queue entry pins its appointment row; the wipe deleted appointments first. No test had ever booked a queue entry, so this stayed hidden until the new coverage landed — at which point all 262 tests errored on the dirty DB. Reviewable independently of the fix.

## Testing

- 9 new tests in `backend/tests/test_appointment_past_booking.py`: elapsed slot rejected, in-progress slot accepted, future accepted, the exact `BOOKING_GRACE` boundary, naive timestamps, both PATCH paths, and both queue-book paths.
- Full backend suite: **262 passed**.
- Frontend `tsc --noEmit` clean; lint shows only a pre-existing `allWindows` warning that also fires on untouched code in the same file.

