### PR TITLE
fix(appointments): prevent double-booking on concurrent submissions

### DIFF
--- a/backend/app/routers/appointments.py
+++ b/backend/app/routers/appointments.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
-from typing import Optional
+from typing import NoReturn, Optional
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import and_, select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
@@ -46,6 +47,7 @@ LIVE_STATES = (
     "awaiting_notes",
 )
 TERMINAL = ("completed", "cancelled")
+DOCTOR_SLOT_CONSTRAINT = "appointments_doctor_slot_unique"
 
 
 def _doctor_for_user(db: Session, user: CurrentUser) -> Doctor:
@@ -82,6 +84,19 @@ def _slot_taken(db: Session, doctor_id: int, scheduled_at: datetime, exclude_id:
     return db.scalar(stmt) is not None
 
 
+def _integrity_constraint(exc: IntegrityError) -> str | None:
+    """Return the Postgres constraint that caused an integrity failure."""
+    return getattr(getattr(exc.orig, "diag", None), "constraint_name", None)
+
+
+def _raise_slot_conflict(db: Session, exc: IntegrityError) -> NoReturn:
+    """Restore the session and translate only the doctor-slot constraint."""
+    db.rollback()
+    if _integrity_constraint(exc) == DOCTOR_SLOT_CONSTRAINT:
+        raise conflict("doctor_slot_taken") from exc
+    raise exc
+
+
 @router.post("", response_model=AppointmentOut, status_code=status.HTTP_201_CREATED,
              dependencies=[Depends(require_role("healthworker"))])
 def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)) -> AppointmentOut:
@@ -101,7 +116,10 @@ def create_appointment(payload: AppointmentCreate, db: Session = Depends(db_dep)
         status="scheduled",
     )
     db.add(appt)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        _raise_slot_conflict(db, exc)
     db.refresh(appt)
     return AppointmentOut.model_validate(appt)
 
@@ -215,7 +233,10 @@ def update_appointment(appt_id: int, payload: AppointmentUpdate, db: Session = D
             raise conflict("doctor_slot_taken")
     appt.doctor_id = new_doctor
     appt.scheduled_at = new_time
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        _raise_slot_conflict(db, exc)
     db.refresh(appt)
     return AppointmentOut.model_validate(appt)
 

--- a/backend/app/routers/consultations.py
+++ b/backend/app/routers/consultations.py
@@ -2,13 +2,14 @@ from datetime import datetime, timedelta, timezone
 
 from fastapi import APIRouter, Depends
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, forbidden, not_found, unprocessable
 from ..dateutils import snap_to_monday
 from ..models import Appointment, Consultation, Doctor, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _raise_slot_conflict, _slot_taken
 from ..schemas import (
     AppointmentOut,
     ConsultationOut,
@@ -28,8 +29,10 @@ def _doctor(db: Session, user: CurrentUser) -> Doctor:
     return d
 
 
-def _own_consultation(db: Session, cid: int, user: CurrentUser) -> tuple[Consultation, Appointment]:
-    c = db.get(Consultation, cid)
+def _own_consultation(
+    db: Session, cid: int, user: CurrentUser, *, for_update: bool = False
+) -> tuple[Consultation, Appointment]:
+    c = db.get(Consultation, cid, with_for_update=for_update)
     if not c:
         raise not_found("consultation_not_found")
     appt = db.get(Appointment, c.appointment_id)
@@ -123,7 +126,10 @@ def patch_consultation(cid: int, payload: ConsultationPatch, db: Session = Depen
                   dependencies=[Depends(require_role("doctor"))])
 def submit_consultation(cid: int, payload: ConsultationSubmitIn, db: Session = Depends(db_dep),
                         user: CurrentUser = Depends(current_user)):
-    c, appt = _own_consultation(db, cid, user)
+    # Serialize submissions for one consultation. Without this lock, two
+    # requests choosing different follow-up slots could both create an
+    # appointment before racing to finalize the same consultation.
+    c, appt = _own_consultation(db, cid, user, for_update=True)
     if c.status != "draft":
         raise conflict("consultation_locked")
     if payload.signature:
@@ -159,7 +165,10 @@ def submit_consultation(cid: int, payload: ConsultationSubmitIn, db: Session = D
             status="scheduled",
         )
         db.add(follow_up_appt)
-        db.flush()
+        try:
+            db.flush()
+        except IntegrityError as exc:
+            _raise_slot_conflict(db, exc)
         c.follow_up_date = payload.followUp.scheduledAt.date()
         c.follow_up_appointment_id = follow_up_appt.appointment_id
     elif isinstance(payload.followUp, FollowUpWeeks):

--- a/backend/app/routers/queue.py
+++ b/backend/app/routers/queue.py
@@ -3,13 +3,14 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, Query, status
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from ..dateutils import snap_to_monday
 from ..deps import CurrentUser, current_user, db_dep, require_role
 from ..errors import conflict, not_found, unprocessable
 from ..models import Appointment, Doctor, Patient, QueueEntry
-from ..routers.appointments import _slot_taken
+from ..routers.appointments import _raise_slot_conflict, _slot_taken
 from ..schemas import (
     AppointmentOut,
     QueueBookIn,
@@ -28,6 +29,14 @@ def _get_entry(db: Session, qid: int) -> QueueEntry:
     if not e:
         raise not_found("queue_entry_not_found")
     return e
+
+
+def _get_entry_for_update(db: Session, qid: int) -> QueueEntry:
+    """Lock a queue row so only one request can claim a pending entry."""
+    entry = db.get(QueueEntry, qid, with_for_update=True)
+    if not entry:
+        raise not_found("queue_entry_not_found")
+    return entry
 
 
 def _existing_pending(db: Session, patient_id: int, source: str) -> list[QueueEntry]:
@@ -162,7 +171,7 @@ def update_queue_entry(qid: int, payload: QueueEntryUpdate,
 @router.post("/{qid}/book", response_model=dict,
              dependencies=[Depends(require_role("healthworker"))])
 def book_queue_entry(qid: int, payload: QueueBookIn, db: Session = Depends(db_dep)):
-    entry = _get_entry(db, qid)
+    entry = _get_entry_for_update(db, qid)
     if entry.status != "pending":
         raise conflict("queue_not_pending", currentStatus=entry.status)
 
@@ -179,12 +188,18 @@ def book_queue_entry(qid: int, payload: QueueBookIn, db: Session = Depends(db_de
         status="scheduled",
     )
     db.add(appt)
-    db.flush()  # get appt.appointment_id without committing
+    try:
+        db.flush()  # get appt.appointment_id without committing
+    except IntegrityError as exc:
+        _raise_slot_conflict(db, exc)
 
     entry.status = "booked"
     entry.appointment_id = appt.appointment_id
     entry.booked_at = datetime.now(timezone.utc)
-    db.commit()
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        _raise_slot_conflict(db, exc)
     db.refresh(entry)
     db.refresh(appt)
     return {

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -152,10 +152,12 @@ def _wipe_setup_state():
         # deleted a few statements down.
         db.execute(text("UPDATE patients SET master_consent_id = NULL"))
         db.execute(text("DELETE FROM consents"))
+        # Booked queue entries reference appointments, so clear them before
+        # deleting their appointment rows.
+        db.execute(text("DELETE FROM queue_entries"))
         db.execute(text("ALTER TABLE appointments DISABLE TRIGGER appointments_locked_guard"))
         db.execute(text("DELETE FROM appointments"))
         db.execute(text("ALTER TABLE appointments ENABLE TRIGGER appointments_locked_guard"))
-        db.execute(text("DELETE FROM queue_entries"))
         db.execute(text("DELETE FROM doctor_availability"))
         db.execute(text("DELETE FROM profile"))
         db.execute(text("DELETE FROM patients"))

--- a/backend/tests/test_appointment_double_booking.py
+++ b/backend/tests/test_appointment_double_booking.py
@@ -1,0 +1,273 @@
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from threading import Barrier
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy import func, select
+
+from app.deps import CurrentUser
+from app.routers import appointments as appointments_router
+from app.routers import consultations as consultations_router
+from app.routers.queue import book_queue_entry
+from app.schemas import (
+    AppointmentCreate,
+    ConsultationSubmitIn,
+    FollowUpAppointment,
+    QueueBookIn,
+)
+
+
+@pytest.fixture
+def booking_records(seeded_doctor, healthworker_account):
+    from app.database import SessionLocal
+    from app.models import Patient, QueueEntry
+
+    db = SessionLocal()
+    try:
+        patient = Patient(
+            given_name="Concurrency",
+            family_name="Patient",
+            gender="female",
+        )
+        db.add(patient)
+        db.flush()
+        queue_entry = QueueEntry(
+            patient_id=patient.patient_id,
+            source="walk_in",
+            created_by=healthworker_account[0],
+        )
+        db.add(queue_entry)
+        db.commit()
+        return patient.patient_id, seeded_doctor.doctor_id, queue_entry.queue_id
+    finally:
+        db.close()
+
+
+@pytest.fixture
+def draft_consultation(seeded_doctor):
+    from app.database import SessionLocal
+    from app.models import Appointment, Consultation, Patient
+
+    db = SessionLocal()
+    try:
+        patient = Patient(
+            given_name="Followup",
+            family_name="Patient",
+            gender="female",
+        )
+        db.add(patient)
+        db.flush()
+        appointment = Appointment(
+            patient_id=patient.patient_id,
+            doctor_id=seeded_doctor.doctor_id,
+            scheduled_at=_future_slot(days=1),
+            status="awaiting_notes",
+        )
+        db.add(appointment)
+        db.flush()
+        consultation = Consultation(
+            appointment_id=appointment.appointment_id,
+            status="draft",
+        )
+        db.add(consultation)
+        db.commit()
+        return (
+            consultation.consultation_id,
+            appointment.appointment_id,
+            patient.patient_id,
+            seeded_doctor.doctor_id,
+            seeded_doctor.username,
+        )
+    finally:
+        db.close()
+
+
+def _future_slot(days: int = 2) -> datetime:
+    return (datetime.now(timezone.utc) + timedelta(days=days)).replace(
+        microsecond=0
+    )
+
+
+def _active_slot_count(doctor_id: int, scheduled_at: datetime) -> int:
+    from app.database import SessionLocal
+    from app.models import Appointment
+
+    db = SessionLocal()
+    try:
+        return db.scalar(
+            select(func.count())
+            .select_from(Appointment)
+            .where(
+                Appointment.doctor_id == doctor_id,
+                Appointment.scheduled_at == scheduled_at,
+                Appointment.status != "cancelled",
+            )
+        )
+    finally:
+        db.close()
+
+
+def test_concurrent_create_forces_unique_constraint_race(
+    monkeypatch, booking_records
+):
+    """Both pre-checks see a free slot; the DB decides one winner."""
+    from app.database import SessionLocal
+
+    patient_id, doctor_id, _ = booking_records
+    scheduled_at = _future_slot()
+    payload = AppointmentCreate(
+        patientId=patient_id,
+        doctorId=doctor_id,
+        scheduledAt=scheduled_at,
+    )
+    both_checked = Barrier(2)
+    original_slot_taken = appointments_router._slot_taken
+
+    def synchronized_slot_taken(db, checked_doctor, checked_at, exclude_id=None):
+        taken = original_slot_taken(
+            db, checked_doctor, checked_at, exclude_id=exclude_id
+        )
+        both_checked.wait(timeout=5)
+        return taken
+
+    monkeypatch.setattr(
+        appointments_router, "_slot_taken", synchronized_slot_taken
+    )
+
+    def create_once(_):
+        db = SessionLocal()
+        try:
+            appointments_router.create_appointment(payload, db)
+            return 201, None
+        except HTTPException as exc:
+            return exc.status_code, exc.detail["error"]
+        finally:
+            db.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(create_once, range(2)))
+
+    assert sorted(status for status, _ in results) == [201, 409]
+    assert next(error for status, error in results if status == 409) == (
+        "doctor_slot_taken"
+    )
+    assert _active_slot_count(doctor_id, scheduled_at) == 1
+
+
+def test_concurrent_queue_booking_claims_entry_once(booking_records):
+    """The row lock prevents one queue entry creating two appointments."""
+    from app.database import SessionLocal
+    from app.models import QueueEntry
+
+    _, doctor_id, queue_id = booking_records
+    scheduled_at = _future_slot(days=3)
+    payload = QueueBookIn(doctorId=doctor_id, scheduledAt=scheduled_at)
+    start = Barrier(2)
+
+    def book_once(_):
+        db = SessionLocal()
+        try:
+            start.wait(timeout=5)
+            result = book_queue_entry(queue_id, payload, db)
+            return 200, result["appointment"]["id"]
+        except HTTPException as exc:
+            return exc.status_code, exc.detail["error"]
+        finally:
+            db.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(book_once, range(2)))
+
+    assert sorted(status for status, _ in results) == [200, 409]
+    assert next(error for status, error in results if status == 409) == (
+        "queue_not_pending"
+    )
+    assert _active_slot_count(doctor_id, scheduled_at) == 1
+
+    db = SessionLocal()
+    try:
+        entry = db.get(QueueEntry, queue_id)
+        assert entry.status == "booked"
+        assert entry.appointment_id is not None
+    finally:
+        db.close()
+
+
+def test_concurrent_consultation_submit_creates_one_follow_up(
+    monkeypatch, draft_consultation
+):
+    """The consultation lock prevents two different follow-ups."""
+    from app.database import SessionLocal
+    from app.models import Appointment, Consultation
+
+    consultation_id, original_id, patient_id, doctor_id, username = (
+        draft_consultation
+    )
+    monkeypatch.setattr(
+        consultations_router, "decode_signature", lambda _value: b"signature"
+    )
+    monkeypatch.setattr(
+        consultations_router, "put_bytes", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        consultations_router,
+        "object_key",
+        lambda *_args, **_kwargs: "test/signature.png",
+    )
+
+    payloads = [
+        ConsultationSubmitIn(
+            signature="test",
+            followUp=FollowUpAppointment(
+                kind="appointment", scheduledAt=_future_slot(days=4)
+            ),
+        ),
+        ConsultationSubmitIn(
+            signature="test",
+            followUp=FollowUpAppointment(
+                kind="appointment", scheduledAt=_future_slot(days=5)
+            ),
+        ),
+    ]
+    user = CurrentUser(username=username, role="doctor")
+    start = Barrier(2)
+
+    def submit_once(payload):
+        db = SessionLocal()
+        try:
+            start.wait(timeout=5)
+            result = consultations_router.submit_consultation(
+                consultation_id, payload, db, user
+            )
+            return 200, result["followUpAppointment"]["id"]
+        except HTTPException as exc:
+            return exc.status_code, exc.detail["error"]
+        finally:
+            db.close()
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        results = list(executor.map(submit_once, payloads))
+
+    assert sorted(status for status, _ in results) == [200, 409]
+    assert next(error for status, error in results if status == 409) == (
+        "consultation_locked"
+    )
+
+    db = SessionLocal()
+    try:
+        follow_up_count = db.scalar(
+            select(func.count())
+            .select_from(Appointment)
+            .where(
+                Appointment.patient_id == patient_id,
+                Appointment.doctor_id == doctor_id,
+                Appointment.appointment_id != original_id,
+            )
+        )
+        consultation = db.get(Consultation, consultation_id)
+        assert follow_up_count == 1
+        assert consultation.status == "completed"
+        assert consultation.follow_up_appointment_id is not None
+    finally:
+        db.close()

--- a/backend/unit_tests/test_slot_conflict_helper.py
+++ b/backend/unit_tests/test_slot_conflict_helper.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.exc import IntegrityError
+
+from app.routers.appointments import (
+    DOCTOR_SLOT_CONSTRAINT,
+    _raise_slot_conflict,
+)
+
+
+class _FakeDriverError(Exception):
+    def __init__(self, constraint_name: str):
+        super().__init__(constraint_name)
+        self.diag = SimpleNamespace(constraint_name=constraint_name)
+
+
+class _FakeSession:
+    def __init__(self):
+        self.rollback_count = 0
+
+    def rollback(self):
+        self.rollback_count += 1
+
+
+def _integrity_error(constraint_name: str) -> IntegrityError:
+    return IntegrityError(
+        "INSERT INTO appointments ...",
+        {},
+        _FakeDriverError(constraint_name),
+    )
+
+
+def test_doctor_slot_constraint_becomes_conflict():
+    db = _FakeSession()
+    error = _integrity_error(DOCTOR_SLOT_CONSTRAINT)
+
+    with pytest.raises(HTTPException) as caught:
+        _raise_slot_conflict(db, error)
+
+    assert caught.value.status_code == 409
+    assert caught.value.detail["error"] == "doctor_slot_taken"
+    assert caught.value.__cause__ is error
+    assert db.rollback_count == 1
+
+
+def test_unrelated_constraint_reraises_original_error():
+    db = _FakeSession()
+    error = _integrity_error("appointments_patient_id_fkey")
+
+    with pytest.raises(IntegrityError) as caught:
+        _raise_slot_conflict(db, error)
+
+    assert caught.value is error
+    assert db.rollback_count == 1

--- a/frontend/src/components/healthworker/appointment-form.tsx
+++ b/frontend/src/components/healthworker/appointment-form.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { zodResolver } from "@hookform/resolvers/zod";
-import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
@@ -93,6 +94,17 @@ export function AppointmentForm({
   // When the picker is in use (no preselected patient), we track the chosen
   // patient locally for the chip display.
   const [picked, setPicked] = useState<Patient | null>(null);
+  const [submissionStarted, setSubmissionStarted] = useState(false);
+  const submissionLock = useRef(false);
+
+  // The ref blocks a second submit before React can render the disabled
+  // button. Keep the local busy state until the parent mutation settles.
+  useEffect(() => {
+    if (!submitting && submissionLock.current) {
+      submissionLock.current = false;
+      setSubmissionStarted(false);
+    }
+  }, [submitting]);
 
   // Hydrate the picker chip when the form arrives with a `defaultPatientId`
   // (e.g. "Book" from a patient profile). The form value is already seeded by
@@ -116,18 +128,28 @@ export function AppointmentForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [prefillQ.data]);
 
-  const submit = handleSubmit((v) =>
-    onSubmit({
-      patientId: v.patientId,
-      doctorId: v.doctorId,
-      // The datetime-local input value is interpreted as APP_TIMEZONE (Sri
-      // Lanka) regardless of the browser's tz, so what the healthworker
-      // types is exactly what gets stored.
-      scheduledAt: appLocalToUtcIso(v.scheduledAt),
-    }),
-  );
+  const submit = handleSubmit((v) => {
+    if (submissionLock.current || submitting) return;
+    submissionLock.current = true;
+    setSubmissionStarted(true);
+    try {
+      onSubmit({
+        patientId: v.patientId,
+        doctorId: v.doctorId,
+        // The datetime-local input value is interpreted as APP_TIMEZONE (Sri
+        // Lanka) regardless of the browser's tz, so what the healthworker
+        // types is exactly what gets stored.
+        scheduledAt: appLocalToUtcIso(v.scheduledAt),
+      });
+    } catch (error) {
+      submissionLock.current = false;
+      setSubmissionStarted(false);
+      throw error;
+    }
+  });
 
   const activeDoctors = doctors.filter((d) => d.active);
+  const busy = submitting || submissionStarted;
 
   return (
     <form onSubmit={submit} className="flex flex-col gap-5">
@@ -193,12 +215,13 @@ export function AppointmentForm({
 
       <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
         {onCancel && (
-          <Button type="button" variant="secondary" onClick={onCancel} disabled={submitting}>
+          <Button type="button" variant="secondary" onClick={onCancel} disabled={busy}>
             Cancel
           </Button>
         )}
-        <Button type="submit" disabled={submitting}>
-          {submitting ? "Booking…" : submitLabel}
+        <Button type="submit" disabled={busy}>
+          {busy && <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" />}
+          {busy ? "Booking…" : submitLabel}
         </Button>
       </div>
     </form>

--- a/frontend/src/components/healthworker/queue-book-form.tsx
+++ b/frontend/src/components/healthworker/queue-book-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Loader2, CalendarPlus } from "lucide-react";
 
 import { Button } from "@/components/primitives/button";
@@ -34,20 +34,38 @@ export function QueueBookForm({
   const [scheduledAt, setScheduledAt] = useState<string>(
     entry.targetDate ? `${entry.targetDate}T09:00` : "",
   );
+  const [submissionStarted, setSubmissionStarted] = useState(false);
+  const submissionLock = useRef(false);
+
+  useEffect(() => {
+    if (!book.isPending && submissionLock.current) {
+      submissionLock.current = false;
+      setSubmissionStarted(false);
+    }
+  }, [book.isPending]);
 
   const submit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (!doctorId || !scheduledAt) return;
-    book.mutate(
-      {
-        doctorId: Number(doctorId),
-        scheduledAt: appLocalToUtcIso(scheduledAt),
-      },
-      {
-        onSuccess: (res) => onBooked(res.appointment),
-      },
-    );
+    if (!doctorId || !scheduledAt || submissionLock.current || book.isPending) return;
+    submissionLock.current = true;
+    setSubmissionStarted(true);
+    try {
+      book.mutate(
+        {
+          doctorId: Number(doctorId),
+          scheduledAt: appLocalToUtcIso(scheduledAt),
+        },
+        {
+          onSuccess: (res) => onBooked(res.appointment),
+        },
+      );
+    } catch (error) {
+      submissionLock.current = false;
+      setSubmissionStarted(false);
+      throw error;
+    }
   };
+  const busy = book.isPending || submissionStarted;
 
   return (
     <form onSubmit={submit} className="flex flex-col gap-4">
@@ -82,12 +100,12 @@ export function QueueBookForm({
       {book.error && <ErrorBanner>{explainError(book.error.error, book.error.message)}</ErrorBanner>}
 
       <div className="flex justify-end gap-2">
-        <Button type="button" variant="secondary" onClick={onCancel} disabled={book.isPending}>
+        <Button type="button" variant="secondary" onClick={onCancel} disabled={busy}>
           Cancel
         </Button>
-        <Button type="submit" disabled={!doctorId || !scheduledAt || book.isPending}>
-          {book.isPending ? <Loader2 className="h-4 w-4 animate-spin" /> : <CalendarPlus className="h-4 w-4" />}
-          {book.isPending ? "Booking…" : "Book appointment"}
+        <Button type="submit" disabled={!doctorId || !scheduledAt || busy}>
+          {busy ? <Loader2 aria-hidden="true" className="h-4 w-4 animate-spin" /> : <CalendarPlus className="h-4 w-4" />}
+          {busy ? "Booking…" : "Book appointment"}
         </Button>
       </div>
     </form>


### PR DESCRIPTION
## Summary

Concurrent `POST /appointments` (and related booking paths) could race the optimistic `_slot_taken` check. The existing partial unique index `appointments_doctor_slot_unique` still allowed only one active doctor slot, but the losing request surfaced as an unhandled `IntegrityError` (HTTP 500). Queue booking and consultation submit had a second gap: two requests could claim the same pending record with *different* slots and leave an orphan appointment.

This PR hardens those paths at the DB and UI layers:

- Translate **only** `appointments_doctor_slot_unique` violations into `409 doctor_slot_taken`; re-raise any other integrity error.
- Lock the queue row (`SELECT … FOR UPDATE`) so one pending entry can create at most one appointment.
- Lock the consultation row on submit so concurrent follow-ups cannot both insert then finalize the same draft.
- Disable Book appointment immediately on first click and show a loading spinner (`AppointmentForm` and `QueueBookForm`).

Fixes #75

This is a follow-up to #103 with stricter constraint handling, row locks, frontend prevention, and deterministic race tests.

## Testing

- `pytest backend/unit_tests/test_slot_conflict_helper.py` — slot constraint → 409; unrelated constraint re-raises the original error (no Postgres required).
- `pytest backend/tests/test_appointment_double_booking.py` — concurrent create (barrier around `_slot_taken`), concurrent queue book, concurrent consultation follow-up; one winner, one conflict, no extra rows.
- Frontend typecheck and lint on the booking forms.

Manual: throttle the browser, double-click Book appointment, confirm one POST, immediate disable, and a spinner until completion.